### PR TITLE
#180417061 NPE fix

### DIFF
--- a/src/main/java/com/dnastack/ga4gh/dataconnect/adapter/trino/TrinoCatalog.java
+++ b/src/main/java/com/dnastack/ga4gh/dataconnect/adapter/trino/TrinoCatalog.java
@@ -66,7 +66,7 @@ public class TrinoCatalog {
             if (log.isTraceEnabled()) {
                 log.error("Error when fetching tables for {}", catalogName, t);
             }
-            return new TablesList(null, throwableTransformer.transform(t, catalogName), null);
+            return new TablesList(null, throwableTransformer.transform(t, catalogName), nextPage);
         }
     }
 }


### PR DESCRIPTION
[Ticket](https://www.pivotaltracker.com/story/show/180417061)

# Description

- We're now showing the pagination value even if there are errors present
- Removed the assertions that checked that there were no errors present in the current page. They're now logged as warnings instead

Sample response when there is error - 
![image](https://user-images.githubusercontent.com/4998821/144308465-0b2668ff-aaa4-4507-a0b4-e502dd98a8be.png)
