### PR TITLE
[#180907761] QueryCleanupManager NPE fix

### DIFF
--- a/src/main/java/com/dnastack/ga4gh/dataconnect/adapter/trino/QueryCleanupManager.java
+++ b/src/main/java/com/dnastack/ga4gh/dataconnect/adapter/trino/QueryCleanupManager.java
@@ -51,9 +51,8 @@ public class QueryCleanupManager {
     @Scheduled(cron = "${app.query-job-cleanup.cron-interval}")
     public void deleteOldQueryJobRows() {
         jdbi.useExtension(QueryJobDao.class, dao -> {
-            List<String> queryJobIdsToBeDeleted = dao.getQueryJobIdsToDelete(queryJobCleanupDeletionTimeoutInDays);
-            log.info("Deleting {} rows from the query_job table", queryJobIdsToBeDeleted.size());
-            dao.deleteOldQueryJobs(queryJobIdsToBeDeleted);
+            var recordsDeleted = dao.deleteOldQueryJobs(queryJobCleanupDeletionTimeoutInDays);
+            log.info("Deleted {} rows from the query_job table", recordsDeleted);
         });
     }
 

--- a/src/main/java/com/dnastack/ga4gh/dataconnect/adapter/trino/QueryCleanupManager.java
+++ b/src/main/java/com/dnastack/ga4gh/dataconnect/adapter/trino/QueryCleanupManager.java
@@ -18,10 +18,10 @@ public class QueryCleanupManager {
     private final Jdbi jdbi;
     private final TrinoClient client;
 
-    @Value("${app.query-cleanup.query-timeout-in-seconds}")
+    @Value("${app.query-cleanup.timeout-in-seconds}")
     private int queryCleanupTimeoutInSeconds;
 
-    @Value("${app.query-job-cleanup.query-deletion-timeout-in-days}")
+    @Value("${app.query-job-cleanup.deletion-timeout-in-days}")
     private int queryJobCleanupDeletionTimeoutInDays;
 
     public QueryCleanupManager(Jdbi jdbi, TrinoClient client) {

--- a/src/main/java/com/dnastack/ga4gh/dataconnect/repository/QueryJobDao.java
+++ b/src/main/java/com/dnastack/ga4gh/dataconnect/repository/QueryJobDao.java
@@ -31,9 +31,6 @@ public interface QueryJobDao {
     @SqlQuery("SELECT * FROM query_job WHERE next_page_url IS NOT NULL AND last_activity_at < :lastActivity AND finished_at IS NULL")
     List<QueryJob> getOldQueries(@Bind Instant lastActivity);
 
-    @SqlQuery("SELECT id FROM query_job WHERE last_activity_at < now()::DATE - :timeoutInDays")
-    List<String> getQueryJobIdsToDelete(@Bind int timeoutInDays);
-
-    @SqlUpdate("DELETE FROM query_job WHERE id IN (<queryJobIds>)")
-    void deleteOldQueryJobs(@BindList List<String> queryJobIds);
+    @SqlUpdate("DELETE FROM query_job WHERE id IN (SELECT id FROM query_job WHERE last_activity_at < now()::DATE - :timeoutInDays)")
+    int deleteOldQueryJobs(@Bind int timeoutInDays);
 }

--- a/src/main/java/com/dnastack/ga4gh/dataconnect/repository/QueryJobDao.java
+++ b/src/main/java/com/dnastack/ga4gh/dataconnect/repository/QueryJobDao.java
@@ -28,7 +28,6 @@ public interface QueryJobDao {
     @SqlUpdate("UPDATE query_job SET last_activity_at = now(), finished_at = now() where id = :id")
     void setQueryFinishedAndLastActivityTime(@Bind String id);
 
-    @SqlQuery("SELECT * FROM query_job WHERE last_activity_at < :lastActivity AND finished_at IS NULL")
     @SqlQuery("SELECT * FROM query_job WHERE (last_activity_at IS NOT NULL AND started_at IS NOT NULL) AND last_activity_at < :lastActivity AND finished_at IS NULL")
     List<QueryJob> getOldQueries(@Bind Instant lastActivity);
 

--- a/src/main/java/com/dnastack/ga4gh/dataconnect/repository/QueryJobDao.java
+++ b/src/main/java/com/dnastack/ga4gh/dataconnect/repository/QueryJobDao.java
@@ -28,7 +28,7 @@ public interface QueryJobDao {
     @SqlUpdate("UPDATE query_job SET last_activity_at = now(), finished_at = now() where id = :id")
     void setQueryFinishedAndLastActivityTime(@Bind String id);
 
-    @SqlQuery("SELECT * FROM query_job WHERE (last_activity_at IS NOT NULL AND started_at IS NOT NULL) AND last_activity_at < :lastActivity AND finished_at IS NULL")
+    @SqlQuery("SELECT * FROM query_job WHERE next_page_url IS NOT NULL AND last_activity_at < :lastActivity AND finished_at IS NULL")
     List<QueryJob> getOldQueries(@Bind Instant lastActivity);
 
     @SqlQuery("SELECT * FROM query_job WHERE last_activity_at < now()::DATE - :timeoutInDays")

--- a/src/main/java/com/dnastack/ga4gh/dataconnect/repository/QueryJobDao.java
+++ b/src/main/java/com/dnastack/ga4gh/dataconnect/repository/QueryJobDao.java
@@ -3,7 +3,7 @@ package com.dnastack.ga4gh.dataconnect.repository;
 import org.jdbi.v3.sqlobject.config.RegisterBeanMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.customizer.BindBean;
-import org.jdbi.v3.sqlobject.statement.SqlCall;
+import org.jdbi.v3.sqlobject.customizer.BindList;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 
@@ -31,6 +31,9 @@ public interface QueryJobDao {
     @SqlQuery("SELECT * FROM query_job WHERE (last_activity_at IS NOT NULL AND started_at IS NOT NULL) AND last_activity_at < :lastActivity AND finished_at IS NULL")
     List<QueryJob> getOldQueries(@Bind Instant lastActivity);
 
-    @SqlQuery("SELECT next_page_url FROM query_job WHERE id = :id")
-    String getNextPageUrl(@Bind String id);
+    @SqlQuery("SELECT * FROM query_job WHERE last_activity_at < now()::DATE - :timeoutInDays")
+    List<String> getQueryJobIdsToDelete(@Bind int timeoutInDays);
+
+    @SqlUpdate("DELETE FROM query_job WHERE query_id IN (<queryJobIds>)")
+    void deleteOldQueryJobs(@BindList List<String> queryJobIds);
 }

--- a/src/main/java/com/dnastack/ga4gh/dataconnect/repository/QueryJobDao.java
+++ b/src/main/java/com/dnastack/ga4gh/dataconnect/repository/QueryJobDao.java
@@ -29,6 +29,7 @@ public interface QueryJobDao {
     void setQueryFinishedAndLastActivityTime(@Bind String id);
 
     @SqlQuery("SELECT * FROM query_job WHERE last_activity_at < :lastActivity AND finished_at IS NULL")
+    @SqlQuery("SELECT * FROM query_job WHERE (last_activity_at IS NOT NULL AND started_at IS NOT NULL) AND last_activity_at < :lastActivity AND finished_at IS NULL")
     List<QueryJob> getOldQueries(@Bind Instant lastActivity);
 
     @SqlQuery("SELECT next_page_url FROM query_job WHERE id = :id")

--- a/src/main/java/com/dnastack/ga4gh/dataconnect/repository/QueryJobDao.java
+++ b/src/main/java/com/dnastack/ga4gh/dataconnect/repository/QueryJobDao.java
@@ -31,7 +31,7 @@ public interface QueryJobDao {
     @SqlQuery("SELECT * FROM query_job WHERE next_page_url IS NOT NULL AND last_activity_at < :lastActivity AND finished_at IS NULL")
     List<QueryJob> getOldQueries(@Bind Instant lastActivity);
 
-    @SqlQuery("SELECT * FROM query_job WHERE last_activity_at < now()::DATE - :timeoutInDays")
+    @SqlQuery("SELECT id FROM query_job WHERE last_activity_at < now()::DATE - :timeoutInDays")
     List<String> getQueryJobIdsToDelete(@Bind int timeoutInDays);
 
     @SqlUpdate("DELETE FROM query_job WHERE id IN (<queryJobIds>)")

--- a/src/main/java/com/dnastack/ga4gh/dataconnect/repository/QueryJobDao.java
+++ b/src/main/java/com/dnastack/ga4gh/dataconnect/repository/QueryJobDao.java
@@ -34,6 +34,6 @@ public interface QueryJobDao {
     @SqlQuery("SELECT * FROM query_job WHERE last_activity_at < now()::DATE - :timeoutInDays")
     List<String> getQueryJobIdsToDelete(@Bind int timeoutInDays);
 
-    @SqlUpdate("DELETE FROM query_job WHERE query_id IN (<queryJobIds>)")
+    @SqlUpdate("DELETE FROM query_job WHERE id IN (<queryJobIds>)")
     void deleteOldQueryJobs(@BindList List<String> queryJobIds);
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -42,10 +42,10 @@ app:
     publisher-catalog-name: publisher_data
   query-cleanup:
     cron-interval: "*/10 * * ? * *" # Every 10 seconds
-    query-timeout-in-seconds: 120
+    timeout-in-seconds: 120
   query-job-cleanup:
     cron-interval: "0 0 1 * * ?" # Every day at 1am
-    query-deletion-timeout-in-days: 1
+    deletion-timeout-in-days: 1
 
 trino:
   datasource:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -40,8 +40,12 @@ app:
     oauth-client:
       resource: "${app.indexing-service.base-uri}"
     publisher-catalog-name: publisher_data
-  query-cleanup-interval: "*/10 * * ? * *" # Every 10 seconds
-  query-cleanup-timeout-in-seconds: 120
+  query-cleanup:
+    cron-interval: "*/10 * * ? * *" # Every 10 seconds
+    query-timeout-in-seconds: 120
+  query-job-cleanup:
+    cron-interval: "0 0 11 * * ?" # Every day at 1am
+    query-deletion-timeout-in-days: 1
 
 trino:
   datasource:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -45,7 +45,7 @@ app:
     timeout-in-seconds: 120
   query-job-cleanup:
     cron-interval: "0 0 1 * * ?" # Every day at 1am
-    deletion-timeout-in-days: 1
+    deletion-timeout-in-days: 7
 
 trino:
   datasource:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -44,7 +44,7 @@ app:
     cron-interval: "*/10 * * ? * *" # Every 10 seconds
     query-timeout-in-seconds: 120
   query-job-cleanup:
-    cron-interval: "0 0 11 * * ?" # Every day at 1am
+    cron-interval: "0 0 1 * * ?" # Every day at 1am
     query-deletion-timeout-in-days: 1
 
 trino:


### PR DESCRIPTION
[Ticket](https://www.pivotaltracker.com/story/show/180907761)

# Description
Handled an edge case that can arise where `started_at` column isn't populated. Also added a `@Scheduled` method to delete old entries from the `query_job` table. 