### PR TITLE
[#181718293] Fix data-connect-trino e2e tests to pass Search Authorization header

### DIFF
--- a/e2e-tests/src/main/java/com/dnastack/ga4gh/dataconnect/adapter/BaseE2eTest.java
+++ b/e2e-tests/src/main/java/com/dnastack/ga4gh/dataconnect/adapter/BaseE2eTest.java
@@ -35,7 +35,7 @@ public abstract class BaseE2eTest {
     protected static RestAssuredConfig config;
     protected static String walletClientId = optionalEnv("E2E_WALLET_CLIENT_ID", "data-connect-trino-e2e-test");
     protected static String walletClientSecret = optionalEnv("E2E_WALLET_CLIENT_SECRET", "dev-secret-never-use-in-prod");
-    protected static String dataConnectAdapterAudience = optionalEnv("E2E_WALLET_AUDIENCE", null);
+    protected static String dataConnectAdapterAudience = optionalEnv("E2E_WALLET_AUDIENCE", "http://localhost:8089");
 
     protected List<Runnable> cleanupOperations = new LinkedList<>();
 


### PR DESCRIPTION
This is needed in order to remove system.metadata.catalogs from the read table whitelist