### PR TITLE
[#182362082] Fix out-of-the-box oauth setup for local dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ mvn clean package
 
 ### Configure
  
-Set these two environment variables.
-```$xslt
+Set these environment variables.
+```
 TRINO_DATASOURCE_URL=https://<your-trino-server>
 SPRING_PROFILES_ACTIVE=no-auth
 ```
@@ -112,7 +112,7 @@ SPRING_SECURITY_USER_PASSWORD={some-password}
 ```
 
 ## Postgres Configuration
-The data connect adapter uses trino to save queries, so that it can reparse them during pagination to re-evaluate functions
+The data connect adapter uses a PostgreSQL database to save queries, so that it can reparse them during pagination to re-evaluate functions
 that need to be processed prior to submitting queries to trino.
 
 The following is a quick start for local development:

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     <version.trino>359</version.trino>
     <version.spring.boot>2.3.8.RELEASE</version.spring.boot>
     <version.guava>30.0-jre</version.guava>
-    <version.nimbus>8.6</version.nimbus>
+    <version.nimbus>9.22</version.nimbus>
     <version.joda>2.10.3</version.joda>
     <version.bouncy.castle>1.67</version.bouncy.castle>
     <feign.version>10.10.1</feign.version>

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -152,11 +152,11 @@ app:
     token-issuers:
       - issuer-uri: http://localhost:8081
         jwk-set-uri: http://localhost:8081/oauth/jwks
-        audiences: ["http://localhost:${server.port}", "http://search-trino.local"]
+        audiences: ["http://localhost:${server.port}"]
 
     trino-oauth-client:
       token-uri: http://localhost:8081/oauth/token
-      client-id: ga4gh-search-adapter-trino
+      client-id: data-connect-trino
       client-secret: dev-secret-never-use-in-prod
       audience: http://trino.local
 ---


### PR DESCRIPTION
This is part of a change that also affects mini-cluster and collection-service. Together, the changes should provide DNAstack developers a working oauth setup out-of-the-box with no custom config required for local development.