### PR TITLE
[#184957085,#184957416] Get schemas from collection-service and return them even if table is empty

### DIFF
--- a/e2e-tests/src/main/java/com/dnastack/ga4gh/dataconnect/adapter/DataConnectE2eTest.java
+++ b/e2e-tests/src/main/java/com/dnastack/ga4gh/dataconnect/adapter/DataConnectE2eTest.java
@@ -785,8 +785,13 @@ public class DataConnectE2eTest extends BaseE2eTest {
         ListTableResponse listTableResponse = globalMethodSecurityEnabled ? getListTableResponse("/tables") :
                 dataConnectApiGetRequest("/tables", 200, ListTableResponse.class);
 
-        assertThat(listTableResponse, not(nullValue()));
-        assertThat(listTableResponse.getTables(), hasSize(greaterThan(0)));
+        if (listTableResponse.getErrors() != null) {
+            // either(empty()).or(nullValue()) would be better, but it was giving compile errors
+            // oneOf(empty(), nullValue()) would be better, but it was failing the assertion when errors was null!
+            assertThat("GET /tables returned an error", listTableResponse.getErrors(), empty());
+        }
+        assertThat("GET /tables returned null response", listTableResponse, not(nullValue()));
+        assertThat("GET /tables returned no tables", listTableResponse.getTables(), hasSize(greaterThan(0)));
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -189,6 +189,17 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>${mockito.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
       <scope>runtime</scope>

--- a/src/main/java/com/dnastack/ga4gh/dataconnect/client/collectionservice/CollectionItem.java
+++ b/src/main/java/com/dnastack/ga4gh/dataconnect/client/collectionservice/CollectionItem.java
@@ -1,0 +1,34 @@
+package com.dnastack.ga4gh.dataconnect.client.collectionservice;
+
+import com.dnastack.ga4gh.dataconnect.model.DataModel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class CollectionItem {
+    private String collectionId;
+    private Instant cachedAt;
+    private String id;
+    private String type;
+    private String dataSourceName;
+    private String dataSourceType;
+    private String name;
+    private String displayName;
+    private String description;
+    private DataModel jsonSchema;
+    private Instant createdTime;
+    private Instant updatedTime;
+    private Long size;
+    private String sizeUnit;
+    private String dataSourceUrl;
+    private Instant itemUpdatedAt;
+}

--- a/src/main/java/com/dnastack/ga4gh/dataconnect/client/collectionservice/CollectionServiceClient.java
+++ b/src/main/java/com/dnastack/ga4gh/dataconnect/client/collectionservice/CollectionServiceClient.java
@@ -1,0 +1,11 @@
+package com.dnastack.ga4gh.dataconnect.client.collectionservice;
+
+import feign.Param;
+import feign.RequestLine;
+
+public interface CollectionServiceClient {
+    @RequestLine("GET /collection/{collectionIdOrSlugNameOrDbSchemaName}/item/{itemIdOrDisplayName}")
+    CollectionItem getItem(
+            @Param("collectionIdOrSlugNameOrDbSchemaName") String collectionIdOrSlugNameOrDbSchemaName,
+            @Param("itemIdOrDisplayName") String itemIdOrDisplayName);
+}

--- a/src/main/java/com/dnastack/ga4gh/dataconnect/client/collectionservice/CollectionServiceClientConfiguration.java
+++ b/src/main/java/com/dnastack/ga4gh/dataconnect/client/collectionservice/CollectionServiceClientConfiguration.java
@@ -1,0 +1,29 @@
+package com.dnastack.ga4gh.dataconnect.client.collectionservice;
+
+import com.dnastack.ga4gh.dataconnect.DataModelSupplier;
+import com.dnastack.oauth.client.OAuthClientFactory;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Slf4j
+@Configuration
+public class CollectionServiceClientConfiguration {
+    @Bean("collectionServiceClient")
+    @ConditionalOnProperty(name = {"app.collection-service.enabled"}, havingValue = "true")
+    public CollectionServiceClient collectionServiceClient(OAuthClientFactory oAuthClientFactory, CollectionServiceConfiguration configuration) {
+        log.info("Initializing the collection-service API client...");
+        return oAuthClientFactory.builderWithCommonSetup(configuration.getOauthClient())
+            .target(CollectionServiceClient.class, configuration.getBaseUri());
+    }
+
+    @Bean
+    @ConditionalOnBean(CollectionServiceClient.class)
+    public DataModelSupplier collectionServiceDataModelSupplier(CollectionServiceClient client, CollectionServiceConfiguration configuration) {
+        log.info("Initializing a collection-service data model supplier for catalog {}", configuration.getCollectionsCatalogName());
+        return new CollectionServiceDataModelSupplier(client, configuration.getCollectionsCatalogName());
+    }
+
+}

--- a/src/main/java/com/dnastack/ga4gh/dataconnect/client/collectionservice/CollectionServiceConfiguration.java
+++ b/src/main/java/com/dnastack/ga4gh/dataconnect/client/collectionservice/CollectionServiceConfiguration.java
@@ -1,0 +1,18 @@
+package com.dnastack.ga4gh.dataconnect.client.collectionservice;
+
+import com.dnastack.oauth.client.OAuthClientConfiguration;
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Data
+@Configuration
+@ConfigurationProperties(prefix = "app.collection-service")
+public class CollectionServiceConfiguration {
+
+    private boolean enabled = false;
+    private String baseUri;
+    private OAuthClientConfiguration oauthClient;
+    private String collectionsCatalogName = null;
+
+}

--- a/src/main/java/com/dnastack/ga4gh/dataconnect/client/collectionservice/CollectionServiceDataModelSupplier.java
+++ b/src/main/java/com/dnastack/ga4gh/dataconnect/client/collectionservice/CollectionServiceDataModelSupplier.java
@@ -1,0 +1,54 @@
+package com.dnastack.ga4gh.dataconnect.client.collectionservice;
+
+import com.dnastack.ga4gh.dataconnect.DataModelSupplier;
+import com.dnastack.ga4gh.dataconnect.model.DataModel;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import feign.FeignException;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class CollectionServiceDataModelSupplier implements DataModelSupplier {
+
+    private final CollectionServiceClient client;
+    private final ObjectMapper objectMapper = new ObjectMapper()
+        .registerModule(new JavaTimeModule())
+        .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+
+
+    private final String collectionsCatalogName;
+
+    public CollectionServiceDataModelSupplier(
+            @NonNull CollectionServiceClient client,
+            @NonNull String collectionsCatalogName) {
+        this.client = client;
+        this.collectionsCatalogName = collectionsCatalogName;
+    }
+
+    @Override
+    public DataModel supply(String fullyQualifiedTableName) {
+        String[] tableNameParts = fullyQualifiedTableName.split("\\.", 3);
+        String catalogName = tableNameParts[0]; // must match this.collectionsCatalogName
+        String schemaName = tableNameParts[1];  // the collection's dbSchemaName
+        String tableName = tableNameParts[2];   // the table's displayName
+
+        if (!catalogName.equals(collectionsCatalogName)) {
+            log.debug("Table not in '{}' catalog. Can't supply data model.", collectionsCatalogName);
+            return null;
+        }
+
+        final CollectionItem collectionItem;
+        try {
+            collectionItem = client.getItem(schemaName, tableName);
+            log.debug("{} CollectionItem is {}", fullyQualifiedTableName, collectionItem);
+            return collectionItem.getJsonSchema();
+        } catch (FeignException e) {
+            log.warn("Failed to fetch collection item for {} -- returning null data model", fullyQualifiedTableName, e);
+            return null;
+        }
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -38,16 +38,16 @@ app:
     enabled: true
     base-uri: http://localhost:8094
     oauth-client:
-      client-id: data-connect-trino
-      client-secret: dev-secret-never-use-in-prod
       scopes: ins:library:read
       resource: "${app.indexing-service.base-uri}/"
-      actions: [ "ins:library:read" ]
-      token-uri: http://localhost:8081/oauth/token
-      token-issuers-uris: [ "http://localhost:8081" ]
-      policy-evaluation-requester: "${app.url}"
-      policy-evaluation-uri: "http://localhost:8081/policies/evaluations"
     publisher-catalog-name: publisher_data
+  collection-service:
+    enabled: true
+    base-uri: http://localhost:8093
+    oauth-client:
+      scopes: collection_item:read
+      resource: "${app.collection-service.base-uri}/"
+    collections-catalog-name: collections
   query-cleanup:
     cron-interval: "*/10 * * ? * *" # Every 10 seconds
     timeout-in-seconds: 120
@@ -72,6 +72,8 @@ info:
 logging:
   level:
     com.dnastack.ga4gh.dataconnect.adapter.trino.TrinoHttpClient: DEBUG # logs queries when search fails
+    com.dnastack.ga4gh.dataconnect.adapter.trino.TrinoDataConnectAdapter: DEBUG
+    com.dnastack.ga4gh.dataconnect.client.collectionservice: DEBUG
     # Reduced the log messages produced by p6spy by default.
     p6spy: WARN
 

--- a/src/test/java/com/dnastack/ga4gh/dataconnect/adapter/trino/TrinoDataConnectAdapterTest.java
+++ b/src/test/java/com/dnastack/ga4gh/dataconnect/adapter/trino/TrinoDataConnectAdapterTest.java
@@ -1,11 +1,144 @@
 package com.dnastack.ga4gh.dataconnect.adapter.trino;
 
+import brave.Tracer;
+import brave.Tracing;
+import com.dnastack.ga4gh.dataconnect.DataModelSupplier;
+import com.dnastack.ga4gh.dataconnect.model.DataModel;
+import com.dnastack.ga4gh.dataconnect.model.TableData;
+import com.dnastack.ga4gh.dataconnect.repository.QueryJob;
+import com.dnastack.ga4gh.dataconnect.repository.QueryJobDao;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import lombok.extern.slf4j.Slf4j;
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.extension.ExtensionCallback;
+import org.jdbi.v3.core.extension.ExtensionConsumer;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
 
+import java.io.UncheckedIOException;
+import java.net.URI;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.hamcrest.collection.IsMapContaining.hasEntry;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
 
+@Slf4j
 public class TrinoDataConnectAdapterTest {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper()
+            .registerModule(new JavaTimeModule())
+            .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+
+    private Tracing tracing;
+    private Tracer.SpanInScope spanInScope;
+
+    /** The object under test */
+    TrinoDataConnectAdapter dataConnectAdapter;
+
+    /**
+     * The data model that will always be returned by the DataModelSupplier. Tests can modify this before calling
+     * into dataConnectAdapter. */
+    DataModel fakeDataModel;
+
+    /**
+     * The source of Trino responses. Tests should load it with Trino response data using
+     * mockTrinoClient.setResponsePages().
+     */
+    MockTrinoClient mockTrinoClient = new MockTrinoClient();
+
+    /**
+     * Managed by the mock QueryJobDao:
+     * Set when create(any) is called; returned when get(any) is called.
+     */
+    QueryJob currentQueryJob;
+
+    static class MockTrinoClient implements TrinoClient {
+
+        private Iterator<String> responsePageIterator;
+
+        void setResponsePages(List<String> responsePages) {
+            responsePageIterator = responsePages.iterator();
+        }
+
+        @Override
+        public JsonNode query(String statement, Map<String, String> extraCredentials) {
+            return next("first", extraCredentials);
+        }
+
+        @Override
+        public JsonNode next(String page, Map<String, String> extraCredentials) {
+            if (responsePageIterator == null) {
+                throw new IllegalStateException("You need to set up some Trino responses by calling setResponsePages()");
+            }
+            try {
+                return objectMapper.readTree(responsePageIterator.next());
+            } catch (JsonProcessingException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+
+        @Override
+        public void killQuery(String nextPageUrl) {
+            log.info("Something called MockTrinoClient.killQuery({})", nextPageUrl);
+        }
+    }
+    @Before
+    public void setUp() throws Exception {
+        tracing = Tracing.newBuilder().build();
+        spanInScope = tracing.tracer().withSpanInScope(tracing.tracer().nextSpan());
+
+        // mock QueryJobDao and JDBI
+        QueryJobDao queryJobDao = mock(QueryJobDao.class);
+        doAnswer(invocation -> {
+            currentQueryJob = invocation.getArgument(0);
+            return currentQueryJob;
+        }).when(queryJobDao).create(any(QueryJob.class));
+        when(queryJobDao.get(any())).thenAnswer(invocation -> Optional.ofNullable(currentQueryJob));
+
+        Jdbi jdbi = mock(Jdbi.class);
+        doAnswer(invocation -> {
+            ExtensionConsumer extensionConsumer = invocation.getArgument(1);
+            extensionConsumer.useExtension(queryJobDao);
+            return null;
+        }).when(jdbi).useExtension(eq(QueryJobDao.class), any());
+        doAnswer(invocation -> {
+            ExtensionCallback extensionCallback = invocation.getArgument(1);
+            return extensionCallback.withExtension(queryJobDao);
+        }).when(jdbi).withExtension(eq(QueryJobDao.class), any());
+
+        fakeDataModel = new DataModel(
+                URI.create("https://exaple.com/test-data-model"),
+                "Test data model",
+                null,
+                Map.of(),
+                null);
+        DataModelSupplier dataModelSupplier = tableName -> fakeDataModel;
+
+        dataConnectAdapter = new TrinoDataConnectAdapter(
+                mockTrinoClient, jdbi, null, null, List.of(dataModelSupplier), tracing
+        );
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        spanInScope.close();
+        tracing.close();
+    }
 
     @Test
     public void biFunctionPatternTest() {
@@ -17,4 +150,174 @@ public class TrinoDataConnectAdapterTest {
         assertTrue(TrinoDataConnectAdapter.biFunctionPattern.matcher(ga4ghTypeFunctionQuery).find());
     }
 
+    @Test
+    public void getTableData_should_includeDataModel_when_supplierProvidesOne_and_tableIsEmpty() throws Exception {
+        mockTrinoClient.setResponsePages(List.of(
+            //language=json
+            """
+            {
+                "id": "fake-req-1",
+                "nextUri": "http://example.com/fake-req-2"
+            }
+            """,
+            //language=json
+            """
+            {
+                "id": "fake-req-1",
+                "columns": [
+                    { "name": "col1", "typeSignature": { "rawType": "varchar" } }
+                ],
+                "data": []
+            }
+            """
+        ));
+
+        // When I try to get table data
+        dataConnectAdapter.getTableData("collections.c1.t1", new MockHttpServletRequest(), Map.of());
+        TableData tableData = dataConnectAdapter.getNextSearchPage("", "fake-req-1", new MockHttpServletRequest(), Map.of());
+
+        // Then
+        assertThat("Adapter should not have found a row of data (this tests that we've mocked Trino correctly)",
+                tableData.getData(), empty());
+        assertThat("Should get the data model produced by the supplier",
+                tableData.getDataModel(), equalTo(fakeDataModel));
+    }
+
+    @Test
+    public void getTableData_should_includeDataModel_when_supplierProvidesOne_and_tableIsNotEmpty() {
+        mockTrinoClient.setResponsePages(List.of(
+                //language=json
+                """
+                {
+                    "id": "fake-req-1",
+                    "nextUri": "http://example.com/fake-req-2"
+                }
+                """,
+                //language=json
+                """
+                {
+                    "id": "fake-req-1",
+                    "columns": [
+                        { "name": "col1", "typeSignature": { "rawType": "varchar" } }
+                    ],
+                    "data": [
+                        [ "val1" ]
+                    ]
+                }
+                """
+        ));
+
+        // When I try to get table data
+        dataConnectAdapter.getTableData("collections.c1.t1", new MockHttpServletRequest(), Map.of());
+        TableData tableData = dataConnectAdapter.getNextSearchPage("", "fake-req-1", new MockHttpServletRequest(), Map.of());
+
+        // Then
+        assertThat("Adapter should have found a row of data (this tests that we've mocked Trino correctly)",
+                tableData.getData(), containsInAnyOrder(hasEntry("col1", "val1")));
+        assertThat("Should get the data model produced by the supplier",
+                tableData.getDataModel(), equalTo(fakeDataModel));
+    }
+
+    @Test
+    public void getTableData_should_generateADataModel_when_supplierProvidesNone_and_tableIsNotEmpty() {
+        mockTrinoClient.setResponsePages(List.of(
+                //language=json
+                """
+                {
+                    "id": "fake-req-1",
+                    "nextUri": "http://example.com/fake-req-2"
+                }
+                """,
+                //language=json
+                """
+                {
+                    "id": "fake-req-1",
+                    "columns": [
+                        { "name": "col1", "typeSignature": { "rawType": "varchar" } }
+                    ],
+                    "data": [
+                        [ "val1" ]
+                    ]
+                }
+                """
+        ));
+        fakeDataModel = null;
+
+        // When I try to get table data
+        dataConnectAdapter.getTableData("collections.c1.t1", new MockHttpServletRequest(), Map.of());
+        TableData tableData = dataConnectAdapter.getNextSearchPage("", "fake-req-1", new MockHttpServletRequest(), Map.of());
+
+        // Then
+        assertThat("Adapter should have found a row of data (this tests that we've mocked Trino correctly)",
+                tableData.getData(), containsInAnyOrder(hasEntry("col1", "val1")));
+        assertThat("Should get the auto-generated data model",
+                tableData.getDataModel(), notNullValue());
+        assertThat("Should get the auto-generated data model",
+                tableData.getDataModel().getDescription(), equalTo("Automatically generated schema"));
+    }
+
+    @Test
+    public void getTableData_shouldNot_generateADataModel_when_supplierProvidesNone_and_tableIsEmpty() {
+        mockTrinoClient.setResponsePages(List.of(
+                //language=json
+                """
+                {
+                    "id": "fake-req-1",
+                    "nextUri": "http://example.com/fake-req-2"
+                }
+                """,
+                //language=json
+                """
+                {
+                    "id": "fake-req-1",
+                    "data": []
+                }
+                """
+        ));
+        fakeDataModel = null;
+
+        // When I try to get table data
+        dataConnectAdapter.getTableData("collections.c1.t1", new MockHttpServletRequest(), Map.of());
+        TableData tableData = dataConnectAdapter.getNextSearchPage("", "fake-req-1", new MockHttpServletRequest(), Map.of());
+
+        // Then
+        assertThat("Adapter should not have found a row of data (this tests that we've mocked Trino correctly)",
+                tableData.getData(), empty());
+        assertThat("Should not get a data model because there was none supplied and Trino gave no column metadata",
+                tableData.getDataModel(), nullValue());
+    }
+
+    @Test
+    public void getTableData_should_generateADataModel_when_supplierProvidesNone_and_trinoResponseHasColumnInfo() {
+        mockTrinoClient.setResponsePages(List.of(
+                //language=json
+                """
+                {
+                    "id": "fake-req-1",
+                    "nextUri": "http://example.com/fake-req-2"
+                }
+                """,
+                //language=json
+                """
+                {
+                    "id": "fake-req-1",
+                    "columns": [
+                        { "name": "col1", "typeSignature": { "rawType": "varchar" } }
+                    ],
+                    "data": []
+                }
+                """
+        ));
+        fakeDataModel = null;
+
+        // When I try to get table data
+        dataConnectAdapter.getTableData("collections.c1.t1", new MockHttpServletRequest(), Map.of());
+        TableData tableData = dataConnectAdapter.getNextSearchPage("", "fake-req-1", new MockHttpServletRequest(), Map.of());
+
+        // Then
+        assertThat("Adapter should not have found a row of data (this tests that we've mocked Trino correctly)",
+                tableData.getData(), empty());
+        assertThat("Should get a data model generated from the column info",
+                tableData.getDataModel().getDescription(), equalTo("Automatically generated schema"));
+    }
 }


### PR DESCRIPTION
Implements a new feature that we need: for tables in the `collections` catalog, get the jsonSchema from the collectionItem, doing the lookup by `dbSchemaName` and `displayName`.

Also fixes a bug which prevented `/table/{tableName}/info` and `/table/{tableName}/data` from producing a schema in the response when the table is empty. 