### PR TITLE
[#185336506] Terminate queries

### DIFF
--- a/src/main/java/com/dnastack/ga4gh/dataconnect/controller/DataConnectController.java
+++ b/src/main/java/com/dnastack/ga4gh/dataconnect/controller/DataConnectController.java
@@ -107,17 +107,14 @@ public class DataConnectController {
         return tableData;
     }
 
-    //TODO: Update the actions/scopes to data-connect:delete?
-    @AuditActionUri("data-connect:next-page")
+    @AuditActionUri("data-connect:delete-query")
     @AuditIgnoreHeaders("GA4GH-Search-Authorization")
     @AuditEventCustomize(QueryJobAppenderAuditEventCustomizer.class)
     @PreAuthorize("hasAuthority('SCOPE_data-connect:query') && hasAuthority('SCOPE_data-connect:data') && @accessEvaluator.canAccessResource('/search/', {'data-connect:query', 'data-connect:data'}, {'data-connect:query', 'data-connect:data'})")
     @DeleteMapping(value = "/search/**")
     public ResponseEntity<?> deleteSearchQuery(@RequestParam("queryJobId") String queryJobId, HttpServletRequest request) {
         log.info("Terminating query with ID: {}", queryJobId);
-
         trinoDataConnectAdapter.deleteQueryJob(queryJobId);
-
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/com/dnastack/ga4gh/dataconnect/controller/DataConnectController.java
+++ b/src/main/java/com/dnastack/ga4gh/dataconnect/controller/DataConnectController.java
@@ -110,9 +110,8 @@ public class DataConnectController {
     @AuditActionUri("data-connect:delete-query")
     @AuditIgnoreHeaders("GA4GH-Search-Authorization")
     @AuditEventCustomize(QueryJobAppenderAuditEventCustomizer.class)
-    @PreAuthorize("hasAuthority('SCOPE_data-connect:query') && hasAuthority('SCOPE_data-connect:data') && @accessEvaluator.canAccessResource('/search/', {'data-connect:query', 'data-connect:data'}, {'data-connect:query', 'data-connect:data'})")
     @DeleteMapping(value = "/search/**")
-    public ResponseEntity<?> deleteSearchQuery(@RequestParam("queryJobId") String queryJobId, HttpServletRequest request) {
+    public ResponseEntity<?> deleteSearchQuery(@RequestParam("queryJobId") String queryJobId) {
         log.info("Terminating query with ID: {}", queryJobId);
         trinoDataConnectAdapter.deleteQueryJob(queryJobId);
         return ResponseEntity.noContent().build();


### PR DESCRIPTION
[Ticket](https://www.pivotaltracker.com/story/show/185336506)

## Description
Added endpoint to allow users to send `DELETE` requests to next page URLs, to terminate the query in Trino. After terminating the query, I decided not to delete it from the `query_job` table, just in case we need to debug/investigate something and want to confirm the query details in the DB. The row will still get deleted by the auto-scheduled job that deletes queries over a week old.

**Question for reviewers:** Should the actions/scopes be data-connect:delete-query or can they be the same as the other controllers (`data-connect:query`, `data-connect:data`)? I was thinking maybe its fine, as the same permission that allows you to submit a search query and get the data, also allows you to terminate the query. 