### PR TITLE
[#186053700] Changed how to convert the stream to an unmodifiable list to avoid NPE

### DIFF
--- a/src/main/java/com/dnastack/ga4gh/dataconnect/adapter/trino/TrinoDataConnectAdapter.java
+++ b/src/main/java/com/dnastack/ga4gh/dataconnect/adapter/trino/TrinoDataConnectAdapter.java
@@ -713,7 +713,7 @@ public class TrinoDataConnectAdapter {
             ColumnSchema itemSchema = columnSchema.getItems();
             return StreamSupport.stream(trinoData.spliterator(), false)
                 .map(arrayValue -> getData(itemSchema, arrayValue))
-                .collect(Collectors.toUnmodifiableList());
+                .toList();
         } else if (columnSchema.getRawType().equals("json")) { //json or primitive.
             try {
                 return objectMapper.readTree(trinoData.asText());

--- a/src/test/java/com/dnastack/ga4gh/dataconnect/adapter/trino/TrinoDataConnectAdapterTest.java
+++ b/src/test/java/com/dnastack/ga4gh/dataconnect/adapter/trino/TrinoDataConnectAdapterTest.java
@@ -188,7 +188,7 @@ public class TrinoDataConnectAdapterTest {
         TableData tableData = dataConnectAdapter.getNextSearchPage("", "fake-req-1", new MockHttpServletRequest(), Map.of());
 
         // Then
-        assertThat("Assertion 1",
+        assertThat("Ensure that the field is not empty",
             (Collection<?>) tableData.getData().get(0).get("col1"), not(empty()));
         assertThat("Ensure that null is included",
             (Collection<?>) tableData.getData().get(0).get("col1"), containsInRelativeOrder("a", "b", null));


### PR DESCRIPTION
| Ticket | 
| --- |
| https://www.pivotaltracker.com/story/show/186053700 |

`Stream.collect(Collectors.toUnmodifiableList())` does not allow `null` in the stream. Upon detection, the collector will raise `NullPointerException`.

The solution here is to use `Stream::toList` which still produce an unmodifiable list with `null`.