### PR TITLE
[#187212155] Update /search to consume "queued" pages and return executing next_page_url

### DIFF
--- a/src/main/java/com/dnastack/ga4gh/dataconnect/controller/DataConnectController.java
+++ b/src/main/java/com/dnastack/ga4gh/dataconnect/controller/DataConnectController.java
@@ -49,6 +49,11 @@ public class DataConnectController {
             log.debug("Request: /search query= {}", dataConnectRequest.getSqlQuery());
             tableData = trinoDataConnectAdapter
                 .search(dataConnectRequest.getSqlQuery(), request, parseCredentialsHeader(clientSuppliedCredentials), null);
+            while (tableData.getPagination().getNextPageUrl().toString().contains("queued")) {
+                tableData = trinoDataConnectAdapter.getNextSearchPage(
+                    tableData.getPagination().getNextPageUrl().getPath().split(request.getContextPath() + "/search/")[1], tableData.getQueryJob().getId(), request,
+                    parseCredentialsHeader(clientSuppliedCredentials));
+            }
         } catch (Exception ex) {
             throw new TableApiErrorException(ex, TableData::errorInstance);
         }


### PR DESCRIPTION
Currently, we're experiencing the following problem in our frontend e2e/journey test suites.

DLFE -> CLS (POST with search query)
CLS -> DCT
DCT -> Gatekeeper
Gatekeeper -> Trino
SAC plugin -> CLS 
<same chain of events back)
DLFE -> CLS (GET next_page_url)
CLS -> DCT
DCT -> Gatekeeper
Gatekeeper -> Trino
SAC plugin -> CLS 
<same chain of events back)
DLFE -> CLS (GET next_page_url)
CLS -> DCT
DCT -> Gatekeeper
Gatekeeper -> Trino
SAC plugin -> CLS 
CLS returns 401/403 as token has been revoked, and subsequent response back the chain is 401/403
The ApiRelayService in DLFE, retries this GET next_page_url 2 times as that's the URL that resulted in the 401/403

To solve this issue, we're thinking that when someone submits a search query to DCT, DCT will submit it to Trino, and then follow the `next_page_url` till the status !=`queued` and then return that as the next_page_url. This will address the above issue, as DLFE will now get the 401/403 on the POST request so it will retry the search request itself, and there will be less network requests for the clients that call DCT (via whatever entry point)