### PR TITLE
[#187212155] Address potential problems when Trino is busy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,7 @@
     <logback-extensions.version>1.0.0</logback-extensions.version>
     <logback.version>1.4.12</logback.version>
     <lombok.version>1.18.30</lombok.version>
+    <resilience4j.version>2.2.0</resilience4j.version>
   </properties>
 
   <dependencies>
@@ -235,6 +236,18 @@
     <dependency>
       <groupId>org.jdbi</groupId>
       <artifactId>jdbi3-jackson2</artifactId>
+    </dependency>
+
+    <!-- Retry -->
+    <dependency>
+      <groupId>io.github.resilience4j</groupId>
+      <artifactId>resilience4j-retry</artifactId>
+      <version>${resilience4j.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.github.resilience4j</groupId>
+      <artifactId>resilience4j-core</artifactId>
+      <version>${resilience4j.version}</version>
     </dependency>
 
     <!--Supporting-->


### PR DESCRIPTION
Hello, based on your feedback I decided to solve the potential problem immediately cause I was afraid that's now or never kind of thing. 

What the new code does is that it waits for job to be executed for ~16s and if job is not in executing state it returns response as it would do with original code - response with `next_page_url`. Question for you is if you're fine with the timeout or if it can cause some issue on your side (Explorer, CLI) because publisher is fine with that. We added javadoc here in DCT and we'll also add that information to CLS OpenAPI.