### PR TITLE
[#187571022]

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -1,3 +1,28 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: dataconnecttrino
+{{- if (coalesce .Values.image.secretName ((.Values.global).image).secretName) }}
+imagePullSecrets:
+  - name: "{{ coalesce .Values.image.secretName ((.Values.global).image).secretName }}"
+{{- end }}
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: dataconnecttrino-{{ .Release.Namespace }}-edit-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: edit
+subjects:
+  - kind: ServiceAccount
+    name: dataconnecttrino
+    namespace: {{ .Release.Namespace }}
+
+---
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -41,9 +66,9 @@ spec:
         tags.datadoghq.com/version: '{{- include  "dnastack.app.version" . }}'
         admission.datadoghq.com/enabled: "true" # Enable Admission Controller to mutate new pods part of this deployment
     spec:
+      serviceAccountName: dataconnecttrino
       initContainers:
         - name: data-connect-trino-cloud-init
-          imagePullPolicy: Always
           image: '{{ coalesce .Values.image.repository ((.Values.global).image).repository }}/data-connect-trino-cloud-init-job:{{- include  "dnastack.cloudinit.version" . }}'
           command: [ "/cloud-init/run_cloud_init.sh" ]
           args: []

--- a/helm/templates/tests/e2etests.yaml
+++ b/helm/templates/tests/e2etests.yaml
@@ -11,10 +11,10 @@ spec:
       labels:
         admission.datadoghq.com/enabled: "true" # Enable Admission Controller to mutate new pods part of this deployment
     spec:
+      serviceAccountName: dataconnecttrino
       containers:
         - name: "data-connect-trino-e2etest"
           image: '{{ coalesce .Values.image.repository ((.Values.global).image).repository }}/data-connect-trino-e2e-tests:{{ .Chart.Version }}'
-          imagePullPolicy: Always
           env:
             - name: _JAVA_OPTIONS
               value: "-Dlogging.level.root=TRACE"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -9,6 +9,7 @@ global:
       version:
   image:
     repository:
+    secretName:
   auditLogService:
     appName: audit-log-service # Host portion of the audit-log-service URL e.g. audit-log-service
   collectionService:
@@ -25,7 +26,8 @@ global:
     appName: wallet # Host portion of the wallet URL to be used for authorization e.g. wallet
 
 image:
-  repository: # Docker repository to pull the image from
+  secretName: # the image pull secret used to pull images from GCP artifact registry
+  repository: # docker repository to pull the image from
 
 app:
   configVersion: config-version


### PR DESCRIPTION
Preparation work for the ultimate goal of moving away from init containers and using the wallet-operator to generate all resources created by cloud-init scripts.

- Create app-specific service account and assign this service account to run all pods/deployments/jobs
- Grant this account the `edit` ClusterRole which is much less-permissive role than cluster-admin. This removes the need for the current `default` service account that has the cluster-admin role.