### PR TITLE
[CU-86b2eg68r] Recognize trino error strings mid-message as well

### DIFF
--- a/src/main/java/com/dnastack/ga4gh/dataconnect/adapter/trino/TrinoDataConnectAdapter.java
+++ b/src/main/java/com/dnastack/ga4gh/dataconnect/adapter/trino/TrinoDataConnectAdapter.java
@@ -489,13 +489,13 @@ public class TrinoDataConnectAdapter {
             throw new TrinoNoSuchColumnException(trinoError);
         } else if (trinoError.getErrorType().equals("USER_ERROR")) {
             if (trinoError.getErrorName().equals("PERMISSION_DENIED")) {
-                if (trinoError.getMessage().startsWith("Access Denied: HTTP 500")) {
+                if (trinoError.getMessage().contains("Access Denied: HTTP 500")) {
                     throw new TrinoInternalErrorException(trinoError);
-                } else if (trinoError.getMessage().startsWith("Access Denied: HTTP 404")) {
+                } else if (trinoError.getMessage().contains("Access Denied: HTTP 404")) {
                     throw new TrinoNoSuchTableException(trinoError);
-                } else if (trinoError.getMessage().startsWith("Access Denied: HTTP 401")) {
+                } else if (trinoError.getMessage().contains("Access Denied: HTTP 401")) {
                     throw new TrinoUserUnauthorizedException(trinoError);
-                } else if (trinoError.getMessage().startsWith("Access Denied: HTTP 403")) {
+                } else if (trinoError.getMessage().contains("Access Denied: HTTP 403")) {
                     throw new TrinoUserForbiddenException(trinoError);
                 }
             }


### PR DESCRIPTION
This closes a gap in our error status code propagation: certain Trino calls
include prepended text that cause data-connect-trino not to detect which
HTTP status code to send back to the client. In turn, this interferes with
the clients' abilities to refresh expired/revoked tokens.
