### PR TITLE
[CU-86b4cpnmp] Log query ID when handling errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,8 +83,12 @@
     <feign-form.version>3.8.0</feign-form.version>
     <logback-extensions.version>1.0.0</logback-extensions.version>
     <logback.version>1.4.12</logback.version>
-    <lombok.version>1.18.30</lombok.version>
+    <lombok.version>1.18.36</lombok.version>
     <resilience4j.version>2.2.0</resilience4j.version>
+
+    <!-- Testing - Java 23 support. These overrides can be removed when we upgrade spring-boot-starter-parent to a version that supports Java 23. -->
+    <mockito.version>5.15.2</mockito.version>
+    <byte-buddy.version>1.14.16</byte-buddy.version>
   </properties>
 
   <dependencies>
@@ -321,6 +325,13 @@
         <configuration>
           <source>${java.version}</source>
           <target>${java.version}</target>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>org.projectlombok</groupId>
+              <artifactId>lombok</artifactId>
+              <version>${lombok.version}</version>
+            </path>
+          </annotationProcessorPaths>
         </configuration>
       </plugin>
     </plugins>

--- a/src/main/java/com/dnastack/ga4gh/dataconnect/adapter/trino/TrinoDataConnectAdapter.java
+++ b/src/main/java/com/dnastack/ga4gh/dataconnect/adapter/trino/TrinoDataConnectAdapter.java
@@ -475,7 +475,8 @@ public class TrinoDataConnectAdapter {
         jdbi.useExtension(QueryJobDao.class, dao -> dao.setQueryFinishedAndLastActivityTime(queryJob.getId()));
 
         TrinoError trinoError = trinoPage.error();
-        log.info("Returning Trino exception: {} {}",
+        log.info("Returning Trino exception for query {}: {} {}",
+            queryJob.getId(),
             trinoError.getFailureInfo().getType(),
             trinoError.getFailureInfo().getMessage());
 
@@ -504,10 +505,10 @@ public class TrinoDataConnectAdapter {
         } else if (trinoError.getErrorType().equals("INSUFFICIENT_RESOURCES")) {
             throw new TrinoInsufficientResourcesException(trinoError);
         } else {
-            // For unexpected execptions, it's usually a programming error or a tricky configuration issue.
+            // For unexpected exceptions, it's usually a programming error or a tricky configuration issue.
             // Either way, we need more diagnostic information. This is the only place where this stack trace
             // will be logged. Only the exception type and message is sent to the client.
-            log.warn("Unexpected {}", trinoError);
+            log.warn("Internal error in query {}: {}", queryJob.getId(), trinoError);
             throw new TrinoInternalErrorException(trinoError.withoutStackTraces());
         }
     }


### PR DESCRIPTION
This change will make it easier to track down errors, and it will also be easier
to link directly to log messages containing the stack trace of the internal error
in our DataDog alerts that watch for Trino internal errors.
