### PR TITLE
[CU-86b4frdzu] Refactor TrinoDataConnectAdapter to improve pagination logic and enhance clarity

### DIFF
--- a/src/main/java/com/dnastack/ga4gh/dataconnect/adapter/trino/CatalogWithSchema.java
+++ b/src/main/java/com/dnastack/ga4gh/dataconnect/adapter/trino/CatalogWithSchema.java
@@ -1,0 +1,13 @@
+package com.dnastack.ga4gh.dataconnect.adapter.trino;
+
+import java.util.Comparator;
+
+public record CatalogWithSchema(String catalogName, String schema) implements Comparable<CatalogWithSchema> {
+    @Override
+    public int compareTo(CatalogWithSchema o) {
+
+        return Comparator.comparing(CatalogWithSchema::catalogName)
+                .thenComparing(CatalogWithSchema::schema)
+                .compare(this, o);
+    }
+}

--- a/src/main/java/com/dnastack/ga4gh/dataconnect/adapter/trino/CatalogWithSchema.java
+++ b/src/main/java/com/dnastack/ga4gh/dataconnect/adapter/trino/CatalogWithSchema.java
@@ -1,13 +1,3 @@
 package com.dnastack.ga4gh.dataconnect.adapter.trino;
 
-import java.util.Comparator;
-
-public record CatalogWithSchema(String catalogName, String schema) implements Comparable<CatalogWithSchema> {
-    @Override
-    public int compareTo(CatalogWithSchema o) {
-
-        return Comparator.comparing(CatalogWithSchema::catalogName)
-                .thenComparing(CatalogWithSchema::schema)
-                .compare(this, o);
-    }
-}
+public record CatalogWithSchema(String catalogName, String schema) { }


### PR DESCRIPTION
This pull request introduces significant changes to the `TrinoDataConnectAdapter` class to improve the handling of catalogs and schemas, including the addition of a new `CatalogWithSchema` record. The key changes are as follows:

### Introduction of `CatalogWithSchema` record:
* Created a new record `CatalogWithSchema` to encapsulate catalog and schema information. (`src/main/java/com/dnastack/ga4gh/dataconnect/adapter/trino/CatalogWithSchema.java`)

### Refactoring and enhancements in `TrinoDataConnectAdapter`:
* Added a method `generatePageIndex` to create page index entries for catalogs and schemas. (`src/main/java/com/dnastack/ga4gh/dataconnect/adapter/trino/TrinoDataConnectAdapter.java`)
* Refactored `getTables` method to use `CatalogWithSchema` for improved schema handling and pagination. (`src/main/java/com/dnastack/ga4gh/dataconnect/adapter/trino/TrinoDataConnectAdapter.java`)
* Enhanced `getTablesByCatalogAndSchema` to streamline pagination and error handling using `CatalogWithSchema`. (`src/main/java/com/dnastack/ga4gh/dataconnect/adapter/trino/TrinoDataConnectAdapter.java`)

### Documentation improvements:
* Updated JavaDoc comments to reflect the new method signatures and improved descriptions for better clarity. (`src/main/java/com/dnastack/ga4gh/dataconnect/adapter/trino/TrinoDataConnectAdapter.java`)