### PR TITLE
[CU-86b4df937] Update Spring Boot and Logback versions in POM and clean up Dockerfile

### DIFF
--- a/ci/impl/Dockerfile
+++ b/ci/impl/Dockerfile
@@ -23,8 +23,6 @@ ADD target/pom.xml /build/pom.xml
 ADD target/src /build/src
 ADD target/.mvn/ /build/.mvn/
 ADD target/mvnw /build/mvnw
-# Allows us to pass settings.xml configured on local machine or CI server to access private Nexus repo
-ADD target/.m2 /root/.m2
 
 RUN ./mvnw -B de.qaware.maven:go-offline-maven-plugin:resolve-dependencies
 RUN ./mvnw -B versions:set -DnewVersion=${APP_VERSION}

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.2.1</version>
+    <version>3.4.4</version>
     <relativePath/> <!-- lookup parent from repository -->
   </parent>
 
@@ -18,13 +18,6 @@
 
   <dependencyManagement>
     <dependencies>
-      <dependency>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-parent</artifactId>
-        <version>${spring-boot.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
       <dependency>
         <groupId>org.springframework.cloud</groupId>
         <artifactId>spring-cloud-dependencies</artifactId>
@@ -70,7 +63,6 @@
     <oauth-client-factory.version>1.0.1</oauth-client-factory.version>
     <!-- Other -->
     <spring-cloud.version>2021.0.9</spring-cloud.version>
-    <spring-boot.version>3.2.5</spring-boot.version>
     <jdbi.version>3.32.0</jdbi.version>
     <version.okhttp>4.12.0</version.okhttp>
     <version.trino>359</version.trino>
@@ -82,7 +74,7 @@
     <feign.version>13.1</feign.version>
     <feign-form.version>3.8.0</feign-form.version>
     <logback-extensions.version>1.0.0</logback-extensions.version>
-    <logback.version>1.4.12</logback.version>
+    <logback.version>1.5.18</logback.version>
     <lombok.version>1.18.36</lombok.version>
     <resilience4j.version>2.2.0</resilience4j.version>
 


### PR DESCRIPTION
This pull request includes updates to the `Dockerfile` and `pom.xml` to improve dependency management and align with newer versions of key libraries and frameworks. The most important changes involve removing unnecessary configurations, upgrading dependencies, and cleaning up the `pom.xml` file.

### Dependency Updates:
* Updated the Spring Boot version in the `pom.xml` from `3.2.1` to `3.4.4` to use the latest features and fixes.
* Upgraded the `logback.version` from `1.4.12` to `1.5.18` for improved logging capabilities.

### Dependency Management Cleanup:
* Removed the `<spring-boot.version>` property (`3.2.5`) from the `pom.xml` as it is no longer needed.
* Deleted the redundant dependency for `spring-boot-starter-parent` under `<dependencyManagement>`. This cleanup avoids duplication since the parent POM already handles it.

### Dockerfile Simplification:
* Removed the addition of the `.m2` directory to the Docker image, as it is unnecessary for the build process. This reduces the image size and simplifies the build process.