### PR TITLE
[CU-86b4thh22] Add caching when fetching schemas and catalogs 

### DIFF
--- a/e2e-tests/src/test/java/com/dnastack/ga4gh/dataconnect/adapter/DataConnectE2eTest.java
+++ b/e2e-tests/src/test/java/com/dnastack/ga4gh/dataconnect/adapter/DataConnectE2eTest.java
@@ -661,9 +661,7 @@ public class DataConnectE2eTest extends BaseE2eTest {
     }
 
     @Test
-    public void nextPageTrailIsConsistentWithIndexOverFirst10Pages() throws Exception {
-        final int MAX_PAGES_TO_TRAVERSE = 10;
-
+    public void nextPageTrailIsConsistentWithIndex() throws Exception {
         ListTableResponse currentPage = getFirstPageOfTableListing();
 
         if (currentPage.getErrors() != null) {
@@ -680,9 +678,8 @@ public class DataConnectE2eTest extends BaseE2eTest {
         assertThat(currentPage.getPagination(), not(nullValue()));
 
         //assert that the nth page has next url equal to the n+1st index.
-        for (int i = 1; i < Math.min(MAX_PAGES_TO_TRAVERSE, pageIndex.size() - 1); ++i) {
+        for (int i = 1; i <  pageIndex.size() - 1; ++i) {
             log.info("Follow-up: Page {}: Start", i);
-
             currentPage = globalMethodSecurityEnabled ? getListTableResponse(currentPage.getPagination().getNextPageUrl().toString()) :
                     dataConnectApiGetRequest(
                             currentPage.getPagination().getNextPageUrl().toString(),
@@ -705,9 +702,6 @@ public class DataConnectE2eTest extends BaseE2eTest {
                 assertThat(currentPage.getPagination().getNextPageUrl(), is(pageIndex.get(i + 1).getUrl()));
             }
             log.info("Follow-up: Page {}: End", i);
-        }
-        if (pageIndex.size() > MAX_PAGES_TO_TRAVERSE) {
-            log.info("next page trail did not end after " + MAX_PAGES_TO_TRAVERSE + " requests, but was consistent with page index over that range.");
         }
     }
 

--- a/src/main/java/com/dnastack/ga4gh/dataconnect/adapter/trino/CatalogWithSchema.java
+++ b/src/main/java/com/dnastack/ga4gh/dataconnect/adapter/trino/CatalogWithSchema.java
@@ -1,3 +1,0 @@
-package com.dnastack.ga4gh.dataconnect.adapter.trino;
-
-public record CatalogWithSchema(String catalogName, String schema) { }

--- a/src/main/java/com/dnastack/ga4gh/dataconnect/adapter/trino/TrinoDataConnectAdapter.java
+++ b/src/main/java/com/dnastack/ga4gh/dataconnect/adapter/trino/TrinoDataConnectAdapter.java
@@ -305,7 +305,6 @@ public class TrinoDataConnectAdapter {
     }
 
     private URI computeLinkToSchema(String catalog, String schema, HttpServletRequest request) {
-        //return URI.create(callbackBaseUrl(request) + String.format("/tables/catalog/%s/schema/%s", catalog, schema)); // TODO use URIBuilder
         return UriComponentsBuilder.fromUriString(callbackBaseUrl(request))
             .path("/tables/catalog/{catalog}/schema/{schema}")
             .buildAndExpand(catalog, schema)
@@ -313,7 +312,10 @@ public class TrinoDataConnectAdapter {
     }
 
     private URI computeLinkToCatalog(String catalog, HttpServletRequest request) {
-        return URI.create(callbackBaseUrl(request) + String.format("/tables/catalog/%s", catalog)); // TODO use URIBuilder
+        return UriComponentsBuilder.fromUriString(callbackBaseUrl(request))
+            .path("/tables/catalog/{catalog}")
+            .buildAndExpand(catalog)
+            .toUri();
     }
 
     private PageIndexEntry getPageIndexEntryForCatalog(String catalog, String schema, int page, HttpServletRequest request) {

--- a/src/main/java/com/dnastack/ga4gh/dataconnect/adapter/trino/TrinoDataConnectAdapter.java
+++ b/src/main/java/com/dnastack/ga4gh/dataconnect/adapter/trino/TrinoDataConnectAdapter.java
@@ -991,9 +991,7 @@ public class TrinoDataConnectAdapter {
         if (userToken == null) {
             return "anonymous_" + catalog;
         }
-        return catalog + userToken;
-    }
-
+        return catalog + "_" + userToken;
 
     private void attachCommentsToDataModel(
         DataModel dataModel,

--- a/src/main/java/com/dnastack/ga4gh/dataconnect/adapter/trino/TrinoDataConnectAdapter.java
+++ b/src/main/java/com/dnastack/ga4gh/dataconnect/adapter/trino/TrinoDataConnectAdapter.java
@@ -23,6 +23,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.jdbi.v3.core.Jdbi;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -30,6 +31,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.URI;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.*;
 import java.util.function.Function;
@@ -47,19 +49,21 @@ public class TrinoDataConnectAdapter {
 
     /** Tracks a {@code catalog.schema} name pair. */
     public record CatalogSchema(String catalog, String schema) {
+
         @Override
         public String toString() {
             return catalog + "." + schema;
         }
+
     }
 
     //Matches the given name against the pattern <catalog>.<schema>.<table>, "<catalog>"."<schema>"."<table>", or
     //"<catalog>.<schema>.<table>".  Note this pattern is permissive and will often allow misquoted names through.
     private static final Pattern qualifiedNameMatcher =
-            Pattern.compile("^\"?[^\"]+\"?\\.\"?[^\"]+\"?\\.\"?[^\"]+\"?$");
+        Pattern.compile("^\"?[^\"]+\"?\\.\"?[^\"]+\"?\\.\"?[^\"]+\"?$");
 
-    private final Map<String,Set<String>> trinoSchemaCache = new CachingConcurrentHashMap<>(300_000,100, null);
-    private final Map<String,Set<String>> trinoCatalogCache = new CachingConcurrentHashMap<>(300_000,100, null);
+    private final Map<String, Set<String>> trinoSchemaCache;
+    private final Map<String, Set<String>> trinoCatalogCache;
 
     private final TrinoClient client;
 
@@ -74,11 +78,16 @@ public class TrinoDataConnectAdapter {
     private final Tracing tracer;
 
     public TrinoDataConnectAdapter(
-            TrinoClient client,
-            Jdbi jdbi,
-            ApplicationConfig applicationConfig,
-            List<DataModelSupplier> dataModelSuppliers,
-            Tracing tracer
+        TrinoClient client,
+        Jdbi jdbi,
+        ApplicationConfig applicationConfig,
+        List<DataModelSupplier> dataModelSuppliers,
+        Tracing tracer,
+        // We use CachingConcurrentHashMap to cache the schema and catalog names to increase performance
+        // When paginating through the tables
+        @Value("${app.caching.expire-after:PT5M}") Duration expireAfter,
+        @Value("${app.caching.max-size:100}") Integer maxSize
+
     ) {
         this.client = client;
         this.jdbi = jdbi;
@@ -86,9 +95,11 @@ public class TrinoDataConnectAdapter {
         this.dataModelSuppliers = dataModelSuppliers;
         this.tracer = tracer;
         this.objectMapper = new ObjectMapper()
-                .configure(JsonParser.Feature.ALLOW_COMMENTS, true)
-                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-                .findAndRegisterModules();
+            .configure(JsonParser.Feature.ALLOW_COMMENTS, true)
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+            .findAndRegisterModules();
+        trinoSchemaCache =  new CachingConcurrentHashMap<>(expireAfter.toMillis(), maxSize, null);
+        trinoCatalogCache =  new CachingConcurrentHashMap<>(expireAfter.toMillis(), maxSize, null);
     }
 
     private boolean hasMore(TableData tableData) {
@@ -97,7 +108,7 @@ public class TrinoDataConnectAdapter {
 
     // Pattern to match ga4gh_type two argument function
     static final Pattern biFunctionPattern = Pattern.compile("((ga4gh_type)\\(\\s*([^,]+)\\s*,\\s*('[^']+')\\s*\\)((\\s+as)?\\s+((?!FROM\\s+)\\w*))?)",
-            Pattern.DOTALL | Pattern.CASE_INSENSITIVE);
+        Pattern.DOTALL | Pattern.CASE_INSENSITIVE);
 
     @Getter
     static class SQLFunction {
@@ -121,15 +132,15 @@ public class TrinoDataConnectAdapter {
     //with a_argIndex
     private String rewriteQuery(String query, String functionName, int argIndex) {
         return biFunctionPattern.matcher(query)
-                .replaceAll(matchResult -> {
-                    SQLFunction sf = new SQLFunction(matchResult);
-                    if (sf.getFunctionName().equals(functionName)) {
-                        String col = sf.getArgs().get(argIndex);
-                        String alias = sf.getColumnAlias();
-                        return (alias == null) ? col : col + " as " + alias;
-                    }
-                    return matchResult.group(1); //pass function through unchanged.
-                });
+            .replaceAll(matchResult -> {
+                SQLFunction sf = new SQLFunction(matchResult);
+                if (sf.getFunctionName().equals(functionName)) {
+                    String col = sf.getArgs().get(argIndex);
+                    String alias = sf.getColumnAlias();
+                    return (alias == null) ? col : col + " as " + alias;
+                }
+                return matchResult.group(1); //pass function through unchanged.
+            });
     }
 
     // Extracts all two-argument SQL functions from a query.
@@ -144,7 +155,7 @@ public class TrinoDataConnectAdapter {
     private String getGa4ghType(SQLFunction ga4ghFunction) {
         String ga4ghType = ga4ghFunction.getArgs().get(1).strip();
         if ((ga4ghType.startsWith("'") && ga4ghType.endsWith("'")) ||
-                (ga4ghType.startsWith("\"") && ga4ghType.endsWith("\""))) {
+            (ga4ghType.startsWith("\"") && ga4ghType.endsWith("\""))) {
             return ga4ghType.substring(1, ga4ghType.length() - 1);
         } else {
             throw new QueryParsingException("Couldn't parse query: second argument to ga4gh_type must be quoted.");
@@ -177,14 +188,14 @@ public class TrinoDataConnectAdapter {
                 throw new QueryParsingException("Unexpected second argument to ga4gh_type function, must be a valid JSON schema or the $ref:<URL> shorthand");
             }
             newColumnSchema = ColumnSchema.builder()
-                    .ref(parts[1])
-                    .build();
+                .ref(parts[1])
+                .build();
         } else {
             try {
                 newColumnSchema = objectMapper.readValue(ga4ghType, ColumnSchema.class);
             } catch (IOException e) {
                 throw new QueryParsingException("Unexpected second argument to ga4gh_type function, must be a valid JSON schema or the $ref:<URL> shorthand.",
-                        e);
+                    e);
             }
         }
 
@@ -200,10 +211,10 @@ public class TrinoDataConnectAdapter {
     // Perform the given query and gather ALL results, by following Trino's nextUrl links
     // The query should NOT contain any functions that would not be recognized by Trino.
     public TableData searchAll(
-            String statement,
-            HttpServletRequest request,
-            Map<String, String> extraCredentials,
-            DataModel dataModel
+        String statement,
+        HttpServletRequest request,
+        Map<String, String> extraCredentials,
+        DataModel dataModel
     ) {
         log.debug("searchAll: Query: {}", statement);
         TableData tableData = search(statement, request, extraCredentials, dataModel);
@@ -226,10 +237,10 @@ public class TrinoDataConnectAdapter {
     }
 
     public TableData search(
-            String query,
-            HttpServletRequest request,
-            Map<String, String> extraCredentials,
-            DataModel dataModel
+        String query,
+        HttpServletRequest request,
+        Map<String, String> extraCredentials,
+        DataModel dataModel
     ) {
 
         String rewrittenQuery = rewriteQuery(query, "ga4gh_type", 0);
@@ -239,10 +250,10 @@ public class TrinoDataConnectAdapter {
     }
 
     public TableData getNextSearchPage(
-            String page,
-            String queryJobId,
-            HttpServletRequest request,
-            Map<String, String> extraCredentials
+        String page,
+        String queryJobId,
+        HttpServletRequest request,
+        Map<String, String> extraCredentials
     ) {
         TrinoDataPage response = client.next(page, extraCredentials);
         log.debug("[getNextSearchPage]response = {}", response);
@@ -279,14 +290,14 @@ public class TrinoDataConnectAdapter {
 
         var currentTime = Instant.now();
         QueryJob queryJob = QueryJob.builder()
-                .query(query)
-                .id(queryId)
-                .originalTraceId(tracer.currentTraceContext().get().traceIdString())
-                .startedAt(currentTime)
-                .lastActivityAt(currentTime)
-                .schema(tableSchema)
-                .nextPageUrl(nextPageUrl)
-                .build();
+            .query(query)
+            .id(queryId)
+            .originalTraceId(tracer.currentTraceContext().get().traceIdString())
+            .startedAt(currentTime)
+            .lastActivityAt(currentTime)
+            .schema(tableSchema)
+            .nextPageUrl(nextPageUrl)
+            .build();
 
         jdbi.useExtension(QueryJobDao.class, dao -> dao.create(queryJob));
 
@@ -296,9 +307,9 @@ public class TrinoDataConnectAdapter {
     private URI computeLinkToSchema(String catalog, String schema, HttpServletRequest request) {
         //return URI.create(callbackBaseUrl(request) + String.format("/tables/catalog/%s/schema/%s", catalog, schema)); // TODO use URIBuilder
         return UriComponentsBuilder.fromUriString(callbackBaseUrl(request))
-                .path("/tables/catalog/{catalog}/schema/{schema}")
-                .buildAndExpand(catalog, schema)
-                .toUri();
+            .path("/tables/catalog/{catalog}/schema/{schema}")
+            .buildAndExpand(catalog, schema)
+            .toUri();
     }
 
     private URI computeLinkToCatalog(String catalog, HttpServletRequest request) {
@@ -308,18 +319,18 @@ public class TrinoDataConnectAdapter {
     private PageIndexEntry getPageIndexEntryForCatalog(String catalog, String schema, int page, HttpServletRequest request) {
         URI uri = computeLinkToSchema(catalog, schema, request);
         return PageIndexEntry.builder()
-                .catalog(catalog)
-                .schema(schema)
-                .url(uri)
-                .page(page)
-                .build();
+            .catalog(catalog)
+            .schema(schema)
+            .url(uri)
+            .page(page)
+            .build();
     }
 
     private List<PageIndexEntry> generatePageIndex(List<CatalogSchema> catalogSchemas, HttpServletRequest request) {
-        final int[] page = {0};
+        final int[] page = { 0 };
         return catalogSchemas.stream()
-                .map(catalogSchema -> getPageIndexEntryForCatalog(catalogSchema.catalog(), catalogSchema.schema(), page[0]++, request))
-                .toList();
+            .map(catalogSchema -> getPageIndexEntryForCatalog(catalogSchema.catalog(), catalogSchema.schema(), page[0]++, request))
+            .toList();
     }
 
     private TablesList getTables(String currentCatalog, String nextCatalog, HttpServletRequest request, Map<String, String> extraCredentials) {
@@ -339,11 +350,11 @@ public class TrinoDataConnectAdapter {
         }
 
         List<CatalogSchema> catalogSchemas = catalogs.stream()
-                .flatMap(catalog -> getTrinoSchema(request, catalog, extraCredentials)
-                        .stream()
-                        .map(schema -> new CatalogSchema(catalog, schema))
-                )
-                .toList();
+            .flatMap(catalog -> getTrinoSchema(request, catalog, extraCredentials)
+                .stream()
+                .map(schema -> new CatalogSchema(catalog, schema))
+            )
+            .toList();
 
         if (catalogSchemas.isEmpty()) {
             return new TablesList(List.of(), null, null);
@@ -386,10 +397,11 @@ public class TrinoDataConnectAdapter {
      *         specified schema doesn't exist within the catalog.
      */
     public TablesList getTablesByCatalogAndSchema(
-            String catalog,
-            String schemaName,
-            HttpServletRequest request,
-            Map<String, String> extraCredentials) {
+        String catalog,
+        String schemaName,
+        HttpServletRequest request,
+        Map<String, String> extraCredentials
+    ) {
 
         Set<String> catalogs = getTrinoCatalogs(request, extraCredentials);
         if (!catalogs.contains(catalog)) {
@@ -397,14 +409,14 @@ public class TrinoDataConnectAdapter {
         }
 
         List<String> orderedSchemas =
-                getTrinoSchema(request, catalog, extraCredentials).stream()
-                        .sorted()
-                        .toList();
+            getTrinoSchema(request, catalog, extraCredentials).stream()
+                .sorted()
+                .toList();
 
         int schemaIdx = orderedSchemas.indexOf(schemaName);
         if (schemaIdx == -1) {
             throw new TrinoNoSuchCatalogException(
-                    "No such schema " + schemaName + " found in catalog " + catalog);
+                "No such schema " + schemaName + " found in catalog " + catalog);
         }
 
         CatalogSchema current = new CatalogSchema(catalog, schemaName);
@@ -415,34 +427,42 @@ public class TrinoDataConnectAdapter {
         } else {
             List<String> orderedCatalogs = catalogs.stream().sorted().toList();
             List<String> followingCatalogs =
-                    orderedCatalogs.subList(orderedCatalogs.indexOf(catalog) + 1,
-                            orderedCatalogs.size());
+                orderedCatalogs.subList(orderedCatalogs.indexOf(catalog) + 1,
+                    orderedCatalogs.size());
 
             next = firstSchemaOfNextNonEmptyCatalog(
-                    followingCatalogs, request, extraCredentials)
-                    .orElse(null);
+                followingCatalogs, request, extraCredentials)
+                .orElse(null);
         }
 
         return getTables(current, next, request, extraCredentials);
     }
 
     private Optional<CatalogSchema> firstSchemaOfNextNonEmptyCatalog(
-            List<String> catalogsAfterCurrent,
-            HttpServletRequest request,
-            Map<String, String> extraCredentials) {
+        List<String> catalogsAfterCurrent,
+        HttpServletRequest request,
+        Map<String, String> extraCredentials
+    ) {
 
         return catalogsAfterCurrent.stream()
-                .map(cat -> getTrinoSchema(request, cat, extraCredentials).stream()
-                        .sorted()
-                        .map(schema -> new CatalogSchema(cat, schema))
-                        .findFirst()
-                        .orElse(null))
-                .filter(Objects::nonNull)
-                .findFirst();
+            .map(cat -> getTrinoSchema(request, cat, extraCredentials).stream()
+                .sorted()
+                .map(schema -> new CatalogSchema(cat, schema))
+                .findFirst()
+                .orElse(null))
+            .filter(Objects::nonNull)
+            .findFirst();
     }
 
     @Nullable
-    private CatalogSchema findNextCatalogWithSchema(String catalog, HttpServletRequest request, Map<String, String> extraCredentials, int schemaIdx, List<String> orderedSchemas, Set<String> catalogs) {
+    private CatalogSchema findNextCatalogWithSchema(
+        String catalog,
+        HttpServletRequest request,
+        Map<String, String> extraCredentials,
+        int schemaIdx,
+        List<String> orderedSchemas,
+        Set<String> catalogs
+    ) {
         CatalogSchema next;
         if (schemaIdx < orderedSchemas.size() - 1) {
             next = new CatalogSchema(catalog, orderedSchemas.get(schemaIdx + 1));
@@ -451,15 +471,15 @@ public class TrinoDataConnectAdapter {
             int catIdx = orderedCatalogs.indexOf(catalog);
 
             next = orderedCatalogs.stream()
-                    .skip(catIdx + 1)
-                    .map(nextCat -> getTrinoSchema(request, nextCat, extraCredentials).stream()
-                            .sorted()
-                            .map(sch -> new CatalogSchema(nextCat, sch))
-                            .findFirst()
-                            .orElse(null))
-                    .filter(Objects::nonNull)
+                .skip(catIdx + 1)
+                .map(nextCat -> getTrinoSchema(request, nextCat, extraCredentials).stream()
+                    .sorted()
+                    .map(sch -> new CatalogSchema(nextCat, sch))
                     .findFirst()
-                    .orElse(null);
+                    .orElse(null))
+                .filter(Objects::nonNull)
+                .findFirst()
+                .orElse(null);
         }
         return next;
     }
@@ -505,9 +525,9 @@ public class TrinoDataConnectAdapter {
     }
 
     public TableInfo getTableInfo(
-            String tableName,
-            HttpServletRequest request,
-            Map<String, String> extraCredentials
+        String tableName,
+        HttpServletRequest request,
+        Map<String, String> extraCredentials
     ) {
         if (!isValidTrinoName(tableName)) {
             //triggers a 404.
@@ -568,9 +588,9 @@ public class TrinoDataConnectAdapter {
      * @return the converted data
      */
     private TableData toTableData(
-            TrinoDataPage trinoPage,
-            QueryJob queryJob,
-            HttpServletRequest request
+        TrinoDataPage trinoPage,
+        QueryJob queryJob,
+        HttpServletRequest request
     ) {
         if (trinoPage.error() != null) {
             handleErrorResponse(trinoPage, queryJob);
@@ -621,9 +641,9 @@ public class TrinoDataConnectAdapter {
 
         TrinoError trinoError = trinoPage.error();
         log.info("Returning Trino exception for query {}: {} {}",
-                queryJob.getId(),
-                trinoError.getFailureInfo().getType(),
-                trinoError.getFailureInfo().getMessage());
+            queryJob.getId(),
+            trinoError.getFailureInfo().getType(),
+            trinoError.getFailureInfo().getMessage());
 
         if (trinoError.getErrorName().equals("CATALOG_NOT_FOUND")) {
             throw new TrinoNoSuchCatalogException(trinoError);
@@ -665,8 +685,8 @@ public class TrinoDataConnectAdapter {
         Stream<SQLFunction> responseTransformingFunctions = parseSQLBiFunctions(query);
 
         responseTransformingFunctions
-                .filter(sqlFunction -> sqlFunction.functionName.equals("ga4gh_type"))
-                .forEach(sqlFunction -> applyGa4ghTypeSqlFunction(sqlFunction, tableData));
+            .filter(sqlFunction -> sqlFunction.functionName.equals("ga4gh_type"))
+            .forEach(sqlFunction -> applyGa4ghTypeSqlFunction(sqlFunction, tableData));
     }
 
     @SneakyThrows
@@ -730,7 +750,7 @@ public class TrinoDataConnectAdapter {
             // we need to eliminate the default port numbers because of Wallet pickiness
             String scheme = urlBuilder.build().getScheme();
             if (("https".equals(scheme) && !forwardedPort.equals("443")) ||
-                    ("http".equals(scheme) && !forwardedPort.equals("80"))) {
+                ("http".equals(scheme) && !forwardedPort.equals("80"))) {
                 urlBuilder.port(Integer.parseInt(forwardedPort));
             }
         }
@@ -751,15 +771,15 @@ public class TrinoDataConnectAdapter {
     }
 
     private static <T, K, U> Collector<T, ?, Map<K, U>> toLinkedHashMap(
-            Function<? super T, ? extends K> keyMapper,
-            Function<? super T, ? extends U> valueMapper
+        Function<? super T, ? extends K> keyMapper,
+        Function<? super T, ? extends U> valueMapper
     ) {
         return Collectors.toMap(keyMapper,
-                valueMapper,
-                (k, v) -> {
-                    throw new UnexpectedQueryResponseException("Duplicate key " + k);
-                },
-                LinkedHashMap::new);
+            valueMapper,
+            (k, v) -> {
+                throw new UnexpectedQueryResponseException("Duplicate key " + k);
+            },
+            LinkedHashMap::new);
     }
 
 
@@ -819,7 +839,7 @@ public class TrinoDataConnectAdapter {
             return objectMapper.readTree(trinoData.asText());
         } catch (JsonProcessingException e) {
             throw new UnexpectedQueryResponseException(
-                    "JSON came back badly formatted: trinoDataArray.asText() = " + trinoData.asText() + ". Exception message=" + e.getMessage());
+                "JSON came back badly formatted: trinoDataArray.asText() = " + trinoData.asText() + ". Exception message=" + e.getMessage());
         }
     }
 
@@ -827,8 +847,8 @@ public class TrinoDataConnectAdapter {
         if (trinoData.getNodeType() == JsonNodeType.ARRAY) {
             ColumnSchema itemSchema = columnSchema.getItems();
             return StreamSupport.stream(trinoData.spliterator(), false)
-                    .map(arrayValue -> convertTrinoFieldToDataConnect(itemSchema, arrayValue))
-                    .toList();
+                .map(arrayValue -> convertTrinoFieldToDataConnect(itemSchema, arrayValue))
+                .toList();
         } else if (trinoData.getNodeType() == JsonNodeType.NULL) {
             return null;
         } else {
@@ -876,10 +896,10 @@ public class TrinoDataConnectAdapter {
      */
     private Map<String, Object> convertRowColumnFromObject(ColumnSchema columnSchema, JsonNode trinoData) {
         return Streams.stream(trinoData.fields())
-                .map(mapEntry ->
-                        Map.entry(mapEntry.getKey(), convertTrinoFieldToDataConnect(columnSchema.getProperties().get(mapEntry.getKey()), mapEntry.getValue()))
-                )
-                .collect(toLinkedHashMap(Map.Entry::getKey, Map.Entry::getValue));
+            .map(mapEntry ->
+                Map.entry(mapEntry.getKey(), convertTrinoFieldToDataConnect(columnSchema.getProperties().get(mapEntry.getKey()), mapEntry.getValue()))
+            )
+            .collect(toLinkedHashMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
     private Map<String, Object> convertMapColumn(ColumnSchema columnSchema, JsonNode trinoData) {
@@ -898,8 +918,8 @@ public class TrinoDataConnectAdapter {
 
         ColumnSchema mapEntryColumnSchema = columnSchema.getProperties().get("value");
         return Streams.stream(trinoData.fields())
-                .map(mapEntry -> Map.entry(mapEntry.getKey(), convertTrinoFieldToDataConnect(mapEntryColumnSchema, mapEntry.getValue())))
-                .collect(toLinkedHashMap(Map.Entry::getKey, Map.Entry::getValue));
+            .map(mapEntry -> Map.entry(mapEntry.getKey(), convertTrinoFieldToDataConnect(mapEntryColumnSchema, mapEntry.getValue())))
+            .collect(toLinkedHashMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
     private Set<String> getTrinoCatalogs(HttpServletRequest request, Map<String, String> extraCredentials) {
@@ -934,7 +954,7 @@ public class TrinoDataConnectAdapter {
 
     private Set<String> getTrinoSchema(HttpServletRequest request, String catalog, Map<String, String> extraCredentials) {
         String cacheKey = getCacheKey(catalog, extraCredentials);
-        return trinoSchemaCache.computeIfAbsent(cacheKey,k -> getTrinoSchemaNoCache(request,catalog,extraCredentials));
+        return trinoSchemaCache.computeIfAbsent(cacheKey, k -> getTrinoSchemaNoCache(request, catalog, extraCredentials));
     }
 
     @NotNull
@@ -955,16 +975,16 @@ public class TrinoDataConnectAdapter {
         return schemasSet;
     }
 
-    private String getCacheKey(Map<String,String> extraCredentials) {
-            String userToken = extraCredentials.get("userToken");
-            if (userToken == null) {
-                return "anonymous";
-            }
-            return userToken;
+    private String getCacheKey(Map<String, String> extraCredentials) {
+        String userToken = extraCredentials.get("userToken");
+        if (userToken == null) {
+            return "anonymous";
         }
+        return userToken;
+    }
 
 
-    private String getCacheKey(String catalog, Map<String,String> extraCredentials) {
+    private String getCacheKey(String catalog, Map<String, String> extraCredentials) {
         String userToken = extraCredentials.get("userToken");
         if (userToken == null) {
             return "anonymous_" + catalog;
@@ -974,10 +994,10 @@ public class TrinoDataConnectAdapter {
 
 
     private void attachCommentsToDataModel(
-            DataModel dataModel,
-            String tableName,
-            HttpServletRequest request,
-            Map<String, String> extraCredentials
+        DataModel dataModel,
+        String tableName,
+        HttpServletRequest request,
+        Map<String, String> extraCredentials
     ) {
         if (dataModel == null) {
             return;
@@ -1035,6 +1055,7 @@ public class TrinoDataConnectAdapter {
 
     private QueryJob getQueryJob(String id) {
         return jdbi.withExtension(QueryJobDao.class, dao -> dao.get(id))
-                .orElseThrow(() -> new InvalidQueryJobException(id));
+            .orElseThrow(() -> new InvalidQueryJobException(id));
     }
+
 }

--- a/src/test/java/com/dnastack/ga4gh/dataconnect/adapter/trino/TrinoDataConnectAdapterTest.java
+++ b/src/test/java/com/dnastack/ga4gh/dataconnect/adapter/trino/TrinoDataConnectAdapterTest.java
@@ -29,6 +29,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import java.io.UncheckedIOException;
 import java.net.URI;
+import java.time.Duration;
 import java.util.*;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -141,7 +142,7 @@ public class TrinoDataConnectAdapterTest {
         when(mockApplicationConfig.getHiddenCatalogs()).thenReturn(Collections.emptySet()); // Default: no hidden catalogs
 
         dataConnectAdapter = new TrinoDataConnectAdapter(
-                mockTrinoClient, jdbi, mockApplicationConfig, List.of(dataModelSupplier), tracing
+                mockTrinoClient, jdbi, mockApplicationConfig, List.of(dataModelSupplier), tracing, Duration.ofMinutes(5),100
         );
     }
 


### PR DESCRIPTION
This change addresses a performance issue encountered when doing listing of tables. Each time a page was being fetched, we needed to fetch all of the schemas and all of the catalogs. Both of these incur a heavy cost since they end up triggering access checks within the collection service for a large number of collections.

Adding a cache layer
- Uses the users token as the cache key
- It is only kept for 5 minutes (but this is configurable)


We saw a 2x speed up in the query in prod-us (thanks to jonathan using telepresence)