### PR TITLE
[CU-86b354w6a] Replace deprecated Datadog trace propagation property with new property

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -315,8 +315,8 @@ spec:
               value: "false"
             - name: DD_APPSEC_ENABLED
               value: "false"
-            - name: DD_PROPAGATION_STYLE_EXTRACT
-              value: "Datadog,B3"
+            - name: DD_TRACE_PROPAGATION_STYLE
+              value: "datadog,b3single,b3multi"
             - name: DD_TRACE_PARTIAL_FLUSH_MIN_SPANS
               value: "400"
             # Optional environment variables


### PR DESCRIPTION
…th new property

### Summary 
* Replaces the deprecated `DD_PROPAGATION_STYLE_EXTRACT` property with the new `DD_TRACE_PROPAGATION_STYLE` property. 
* Non-functional change
* The change is suggested by Datadog within the logs:

```
[dd.trace 2025-05-15 16:32:34:673 -0400] [main] WARN datadog.trace.api.Config - 
Setting dd.propagation.style.extract is deprecated 
and the value [DATADOG, B3] has been converted to [datadog, b3single, b3multi] 
for setting dd.trace.propagation.style.extract.
```