### PR TITLE
[CU-86b558tve] Centralize DataDog configuration to reduce duplication

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -310,15 +310,11 @@ spec:
             # Auditing
             - name: AUDITING_ENABLED
               value: "true"
-            # Datadog Config
-            - name: DD_PROFILING_ENABLED
-              value: "false"
-            - name: DD_APPSEC_ENABLED
-              value: "false"
-            - name: DD_TRACE_PROPAGATION_STYLE
-              value: "datadog,b3single,b3multi"
-            - name: DD_TRACE_PARTIAL_FLUSH_MIN_SPANS
-              value: "400"
+            # Global instrumentation environment variables (DataDog, etc.)
+            {{- range .Values.global.instrumentation.env }}
+            - name: {{ .name }}
+              value: {{ .value | quote }}
+            {{- end }}
             # Optional environment variables
             {{- range .Values.env }}
             - name: {{ .name }}


### PR DESCRIPTION
## Summary
• Replace hardcoded DataDog environment variables with reference to global instrumentation configuration
• Remove duplicated DD_PROFILING_ENABLED, DD_APPSEC_ENABLED, DD_TRACE_PROPAGATION_STYLE, DD_TRACE_PARTIAL_FLUSH_MIN_SPANS from deployment template
• Use centralized configuration from publisher-helm-chart/profiles/instrumentation-datadog.yaml