### PR TITLE
[CU-86b6jg419] Set higher level of timout for liveness probe

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -179,9 +179,9 @@ spec:
               path: /actuator/health
               port: 8080
               scheme: HTTP
-            periodSeconds: 10
-            timeoutSeconds: 2
-            failureThreshold: 1
+            periodSeconds: 15
+            timeoutSeconds: 30
+            failureThreshold: 3
           env:
             - name: JAVA_OPTS
               value: "-XX:+PrintFlagsFinal -XX:+ExitOnOutOfMemoryError"


### PR DESCRIPTION
Under various performance tests we witnessed that the service would stay under high load longer healthier with a non-aggressive liveness probe settings. Dataconnect will see high load and the liveness probe does not need to have the answers that quickly.