### PR TITLE
[CU-86b8uk21p] Separate liveness and readiness probes across publishe…

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -167,16 +167,24 @@ spec:
               memory: {{ .Values.app.memoryLimit }}
           startupProbe:
             httpGet:
-              path: /actuator/health
+              path: /actuator/health/readiness
               port: 8080
               scheme: HTTP
             initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 2
             failureThreshold: 18 # this will result in a 3 minutes timeout (periodSeconds * failureThreshold)
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: 8080
+              scheme: HTTP
+            periodSeconds: 10
+            timeoutSeconds: 2
+            failureThreshold: 2
           livenessProbe:
             httpGet:
-              path: /actuator/health
+              path: /actuator/health/liveness
               port: 8080
               scheme: HTTP
             periodSeconds: 15

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -122,6 +122,10 @@ management:
         enabled: false
   endpoints:
     web.exposure.include: info, health
+  endpoint:
+    health:
+      probes:
+        enabled: true
 
 ---
 


### PR DESCRIPTION
…r services

  Split Kubernetes probe endpoints from shared /actuator/health to dedicated
  /actuator/health/liveness and /actuator/health/readiness endpoints. Added
  missing readiness probes to services that lacked them, fixed dlcon-gcs from
  /actuator/info to proper health endpoints, and replaced TCP socket probes
  with HTTP on data-lake-frontend.