### PR TITLE
[CU-86b9dr5ta] Add test-secrets.env to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ README.html
 *.tgz
 Chart.lock
 env\.sh
+test-secrets.env


### PR DESCRIPTION
## Summary
- Adds \`test-secrets.env\` to \`.gitignore\` to prevent accidentally committing local e2e test secrets overlay

Follows the existing convention already in place across other publisher services (\`collection-service\`, \`data-lake-frontend\`, \`dlcon-gcs\`, \`dlcon-s3-storage\`, \`dlcon-az-storage\`, \`dlcon-http\`, \`wallet\`, etc.).

## Test plan
- Verify \`git status\` does not show \`e2e-tests/test-secrets.env\` as an untracked file after creating one locally

🤖 Generated with [Claude Code](https://claude.ai/code)