### PR TITLE
[CU-86b9ybg6d] Migrate to java-libraries-monorepo 4.0.0-rc2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,9 +5,9 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.springframework.boot</groupId>
-    <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.5.13</version>
+    <groupId>com.dnastack.starter</groupId>
+    <artifactId>spring-boot-parent</artifactId>
+    <version>4.0.0-rc2-9-gd79f5a8</version>
     <relativePath/> <!-- lookup parent from repository -->
   </parent>
 
@@ -19,33 +19,9 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>org.springframework.cloud</groupId>
-        <artifactId>spring-cloud-dependencies</artifactId>
-        <version>${spring-cloud.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
         <groupId>joda-time</groupId>
         <artifactId>joda-time</artifactId>
         <version>${version.joda}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jdbi</groupId>
-        <artifactId>jdbi3-bom</artifactId>
-        <type>pom</type>
-        <version>${jdbi.version}</version>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>ch.qos.logback</groupId>
-        <artifactId>logback-classic</artifactId>
-        <version>${logback.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>ch.qos.logback</groupId>
-        <artifactId>logback-core</artifactId>
-        <version>${logback.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -57,16 +33,7 @@
     <maven-resources-plugin.version>3.2.0</maven-resources-plugin.version>
     <maven-surefire-plugin.version>3.0.0-M7</maven-surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <!-- DNAstack Libs-->
-    <dnastack-token-validator.version>1.0.18</dnastack-token-validator.version>
-    <audit-event-logger.version>1.0.20</audit-event-logger.version>
-    <oauth-client-factory.version>1.0.5</oauth-client-factory.version>
-    <!-- Pin Jackson to 2.18.x: dnastack-oauth-client-factory-spring-starter 1.0.5 uses
-         removed-in-2.19 PropertyNamingStrategy.SNAKE_CASE API. Remove when bumping the lib. -->
-    <jackson-bom.version>2.18.6</jackson-bom.version>
     <!-- Other -->
-    <spring-cloud.version>2021.0.9</spring-cloud.version>
-    <jdbi.version>3.49.5</jdbi.version>
     <version.okhttp>4.12.0</version.okhttp>
     <version.trino>359</version.trino>
     <version.guava>32.1.3-jre</version.guava>
@@ -76,10 +43,7 @@
     <assertj.version>3.27.7</assertj.version>
     <feign.version>13.6</feign.version>
     <feign-form.version>3.8.0</feign-form.version>
-    <logback-extensions.version>1.0.1</logback-extensions.version>
-    <logback.version>1.5.25</logback.version>
     <lombok.version>1.18.42</lombok.version>
-    <resilience4j.version>2.3.0</resilience4j.version>
 
     <!-- Testing - Java 23 support. These overrides can be removed when we upgrade spring-boot-starter-parent to a version that supports Java 23. -->
     <mockito.version>5.20.0</mockito.version>
@@ -169,7 +133,7 @@
     </dependency>
     <dependency>
       <groupId>io.micrometer</groupId>
-      <artifactId>micrometer-tracing-bridge-brave</artifactId>
+      <artifactId>micrometer-tracing-bridge-otel</artifactId>
     </dependency>
     <dependency>
       <groupId>joda-time</groupId>
@@ -261,62 +225,44 @@
     <dependency>
       <groupId>io.github.resilience4j</groupId>
       <artifactId>resilience4j-retry</artifactId>
-      <version>${resilience4j.version}</version>
     </dependency>
     <dependency>
       <groupId>io.github.resilience4j</groupId>
       <artifactId>resilience4j-core</artifactId>
-      <version>${resilience4j.version}</version>
     </dependency>
 
     <!--Supporting-->
     <dependency>
       <groupId>com.dnastack</groupId>
       <artifactId>dnastack-token-validator</artifactId>
-      <version>${dnastack-token-validator.version}</version>
     </dependency>
 
     <!-- Audit Event Logger -->
     <dependency>
       <groupId>com.dnastack</groupId>
       <artifactId>spring-boot-audit-event-logger</artifactId>
-      <version>${audit-event-logger.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>io.zipkin.reporter2</groupId>
-          <artifactId>zipkin-reporter-metrics-micrometer</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>io.zipkin.reporter2</groupId>
-          <artifactId>zipkin-reporter</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <dependency>
       <groupId>com.dnastack</groupId>
       <artifactId>dnastack-oauth-client-factory-spring-starter</artifactId>
-      <version>${oauth-client-factory.version}</version>
     </dependency>
 
     <!-- Customized Logging -->
     <dependency>
       <groupId>com.dnastack</groupId>
       <artifactId>logback-extensions</artifactId>
-      <version>${logback-extensions.version}</version>
     </dependency>
 
     <!-- Zonky Test-->
     <dependency>
       <groupId>io.zonky.test</groupId>
       <artifactId>embedded-database-spring-test</artifactId>
-      <version>2.6.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.zonky.test</groupId>
       <artifactId>embedded-postgres</artifactId>
-      <version>2.1.1</version>
       <scope>test</scope>
     </dependency>
 

--- a/src/main/java/com/dnastack/ga4gh/dataconnect/ApplicationConfig.java
+++ b/src/main/java/com/dnastack/ga4gh/dataconnect/ApplicationConfig.java
@@ -1,10 +1,10 @@
 package com.dnastack.ga4gh.dataconnect;
 
-import brave.Tracing;
 import com.dnastack.auth.JwtTokenParser;
 import com.dnastack.auth.JwtTokenParserFactory;
 import com.dnastack.auth.PermissionChecker;
 import com.dnastack.auth.PermissionCheckerFactory;
+import com.dnastack.auth.client.OidcHttpClient;
 import com.dnastack.auth.client.TokenActionsHttpClientFactory;
 import com.dnastack.auth.keyresolver.CachingIssuerPubKeyJwksResolver;
 import com.dnastack.auth.keyresolver.IssuerPubKeyStaticResolver;
@@ -21,8 +21,10 @@ import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.JwsHeader;
 import io.jsonwebtoken.JwtException;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.observation.ObservationRegistry;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import okhttp3.ConnectionPool;
 import okhttp3.OkHttpClient;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -96,9 +98,14 @@ public class ApplicationConfig {
     }
 
     @Bean
-    public TrinoClient getTrinoClient(OkHttpClient httpClient, Tracing tracing, ServiceAccountAuthenticator accountAuthenticator, MeterRegistry registry) {
+    public TrinoClient getTrinoClient(OkHttpClient httpClient, io.micrometer.tracing.Tracer tracer, ServiceAccountAuthenticator accountAuthenticator, MeterRegistry registry) {
         return new TrinoTelemetryClient(
-            new TrinoHttpClient(tracing, httpClient, trinoDatasourceUrl, accountAuthenticator), registry);
+            new TrinoHttpClient(tracer, httpClient, trinoDatasourceUrl, accountAuthenticator), registry);
+    }
+
+    @Bean
+    public ConnectionPool tokenValidatorConnectionPool() {
+        return new ConnectionPool();
     }
 
     @Bean
@@ -210,7 +217,12 @@ public class ApplicationConfig {
         }
 
         @Bean
-        public List<IssuerInfo> allowedIssuers(AuthConfig authConfig) {
+        public OidcHttpClient oidcHttpClient(ObservationRegistry observationRegistry, ConnectionPool tokenValidatorConnectionPool) {
+            return new OidcHttpClient(observationRegistry, tokenValidatorConnectionPool);
+        }
+
+        @Bean
+        public List<IssuerInfo> allowedIssuers(AuthConfig authConfig, OidcHttpClient oidcHttpClient) {
             List<AuthConfig.IssuerConfig> issuers = authConfig.getTokenIssuers();
             if (issuers == null || issuers.isEmpty()) {
                 throw new IllegalArgumentException("At least one token issuer must be defined");
@@ -224,7 +236,7 @@ public class ApplicationConfig {
                         .allowedAudiences(issuerConfig.getAudiences())
                         .publicKeyResolver(issuerConfig.getRsaPublicKey() != null
                             ? new IssuerPubKeyStaticResolver(issuerUri, issuerConfig.getRsaPublicKey())
-                            : new CachingIssuerPubKeyJwksResolver(issuerUri))
+                            : CachingIssuerPubKeyJwksResolver.create(issuerUri, oidcHttpClient))
                         .build();
                 })
                 .toList();
@@ -236,10 +248,11 @@ public class ApplicationConfig {
             List<IssuerInfo> allowedIssuers,
             @Value("${app.url}") String policyEvaluationRequester,
             @Value("${app.auth.token-issuers[0].issuer-uri}") String walletUrl,
-            Tracing tracing
+            ObservationRegistry observationRegistry,
+            ConnectionPool tokenValidatorConnectionPool
         ) {
             String policyEvaluationUrl = stripTrailingSlashes(walletUrl) + "/policies/evaluations";
-            return PermissionCheckerFactory.create(allowedIssuers, policyEvaluationRequester, policyEvaluationUrl, tracing);
+            return PermissionCheckerFactory.create(allowedIssuers, policyEvaluationRequester, policyEvaluationUrl, observationRegistry, tokenValidatorConnectionPool);
         }
 
         private String stripTrailingSlashes(String url) {
@@ -251,8 +264,9 @@ public class ApplicationConfig {
         }
 
         @Bean
-        public JwtDecoder jwtDecoder(List<IssuerInfo> allowedIssuers, PermissionChecker permissionChecker, Tracing tracing) {
-            final JwtTokenParser jwtTokenParser = JwtTokenParserFactory.create(allowedIssuers, TokenActionsHttpClientFactory.create(tracing));
+        public JwtDecoder jwtDecoder(List<IssuerInfo> allowedIssuers, PermissionChecker permissionChecker, ObservationRegistry observationRegistry, ConnectionPool tokenValidatorConnectionPool) {
+            final JwtTokenParser jwtTokenParser = JwtTokenParserFactory.create(allowedIssuers,
+                TokenActionsHttpClientFactory.create(observationRegistry, tokenValidatorConnectionPool));
             return (jwtToken) -> {
                 try {
                     permissionChecker.checkPermissions(jwtToken);

--- a/src/main/java/com/dnastack/ga4gh/dataconnect/adapter/shared/DataConnectAuthRequest.java
+++ b/src/main/java/com/dnastack/ga4gh/dataconnect/adapter/shared/DataConnectAuthRequest.java
@@ -1,13 +1,13 @@
 package com.dnastack.ga4gh.dataconnect.adapter.shared;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Value;
 
 import java.util.Map;
 
 @Value
-@JsonNaming(PropertyNamingStrategy.KebabCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
 public class DataConnectAuthRequest {
     String key;
     String resourceType;

--- a/src/main/java/com/dnastack/ga4gh/dataconnect/adapter/shared/GlobalControllerExceptionHandler.java
+++ b/src/main/java/com/dnastack/ga4gh/dataconnect/adapter/shared/GlobalControllerExceptionHandler.java
@@ -1,6 +1,6 @@
 package com.dnastack.ga4gh.dataconnect.adapter.shared;
 
-import brave.Tracer;
+import io.micrometer.tracing.Tracer;
 import com.dnastack.ga4gh.dataconnect.adapter.trino.exception.TableApiErrorException;
 import com.dnastack.ga4gh.dataconnect.model.TableError;
 import lombok.extern.slf4j.Slf4j;
@@ -24,12 +24,12 @@ public class GlobalControllerExceptionHandler {
         return ResponseEntity.status(401)
             .contentType(MediaType.APPLICATION_JSON_UTF8)
             .header("WWW-Authenticate", "GA4GH-Search realm=\"" + escapeQuotes(cr.getKey()) + "\"")
-            .body(Map.of("authorization-request", cr, "trace_id", tracer.currentSpan().context().traceIdString()));
+            .body(Map.of("authorization-request", cr, "trace_id", tracer.currentSpan().context().traceId()));
     }
 
     @ExceptionHandler({TableApiErrorException.class})
     public ResponseEntity<?> handleTableApiErrorException(TableApiErrorException throwable) {
-        String traceId = tracer.currentSpan().context().traceIdString();
+        String traceId = tracer.currentSpan().context().traceId();
         TableError error = TableError.fromThrowable(throwable.getCause(), null);
         log.error("Generating response with error that escaped controller: {}", error, throwable);
 

--- a/src/main/java/com/dnastack/ga4gh/dataconnect/adapter/trino/TrinoDataConnectAdapter.java
+++ b/src/main/java/com/dnastack/ga4gh/dataconnect/adapter/trino/TrinoDataConnectAdapter.java
@@ -1,6 +1,5 @@
 package com.dnastack.ga4gh.dataconnect.adapter.trino;
 
-import brave.Tracing;
 import com.dnastack.auth.cache.CachingConcurrentHashMap;
 import com.dnastack.ga4gh.dataconnect.ApplicationConfig;
 import com.dnastack.ga4gh.dataconnect.DataModelSupplier;
@@ -15,6 +14,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeType;
 import com.google.common.collect.Streams;
+import io.micrometer.tracing.Tracer;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.Getter;
 import lombok.SneakyThrows;
@@ -86,14 +86,14 @@ public class TrinoDataConnectAdapter {
 
     private final ObjectMapper objectMapper;
 
-    private final Tracing tracer;
+    private final Tracer tracer;
 
     public TrinoDataConnectAdapter(
         TrinoClient client,
         Jdbi jdbi,
         ApplicationConfig applicationConfig,
         List<DataModelSupplier> dataModelSuppliers,
-        Tracing tracer,
+        Tracer tracer,
         // We use CachingConcurrentHashMap to cache the schema and catalog names to increase performance
         // When paginating through the tables
         @Value("${app.caching.expire-after:PT5M}") Duration expireAfter,
@@ -309,7 +309,7 @@ public class TrinoDataConnectAdapter {
         QueryJob queryJob = QueryJob.builder()
             .query(query)
             .id(queryId)
-            .originalTraceId(tracer.currentTraceContext().get().traceIdString())
+            .originalTraceId(tracer.currentTraceContext().context().traceId())
             .startedAt(currentTime)
             .lastActivityAt(currentTime)
             .schema(tableSchema)

--- a/src/main/java/com/dnastack/ga4gh/dataconnect/adapter/trino/TrinoHttpClient.java
+++ b/src/main/java/com/dnastack/ga4gh/dataconnect/adapter/trino/TrinoHttpClient.java
@@ -1,9 +1,5 @@
 package com.dnastack.ga4gh.dataconnect.adapter.trino;
 
-import brave.Span;
-import brave.Tracer;
-import brave.Tracing;
-import brave.propagation.B3SingleFormat;
 import com.dnastack.ga4gh.dataconnect.adapter.security.ServiceAccountAuthenticator;
 import com.dnastack.ga4gh.dataconnect.adapter.shared.AuthRequiredException;
 import com.dnastack.ga4gh.dataconnect.adapter.shared.DataConnectAuthRequest;
@@ -14,6 +10,9 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.micrometer.tracing.Span;
+import io.micrometer.tracing.Tracer;
+import io.micrometer.tracing.TraceContext;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.OkHttpClient;
@@ -46,22 +45,20 @@ public class TrinoHttpClient implements TrinoClient {
     private final ServiceAccountAuthenticator authenticator;
     private final OkHttpClient httpClient;
     private final Tracer tracer;
-    private Tracing tracing;
     private final ObjectMapper objectMapper = new ObjectMapper()
         .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
-    public TrinoHttpClient(Tracing tracing, OkHttpClient httpClient, String trinoServerUrl, ServiceAccountAuthenticator accountAuthenticator) {
+    public TrinoHttpClient(Tracer tracer, OkHttpClient httpClient, String trinoServerUrl, ServiceAccountAuthenticator accountAuthenticator) {
         this.trinoServer = trinoServerUrl;
         this.trinoSearchEndpoint = trinoServerUrl + "/v1/statement";
         this.authenticator = accountAuthenticator;
-        this.tracing = tracing;
-        this.tracer = tracing.tracer();
+        this.tracer = tracer;
         this.httpClient = httpClient;
     }
 
     public TrinoDataPage query(String statement, Map<String, String> extraCredentials) {
-        Span span = tracer.nextSpan().name("trinoQuery");
-        try (Tracer.SpanInScope ws = tracer.withSpanInScope(span.start())) {
+        Span span = tracer.nextSpan().name("trinoQuery").start();
+        try (Tracer.SpanInScope ws = tracer.withSpan(span)) {
                 log.debug("Posting to " + trinoSearchEndpoint);
             try (Response response = post(trinoSearchEndpoint, statement, extraCredentials)) {
                 log.debug("Got response, now polling for query results");
@@ -73,14 +70,14 @@ public class TrinoHttpClient implements TrinoClient {
                 throw new TrinoIOException("Unable to initiate search (I/O error).", e);
             }
         } finally {
-            span.finish();
+            span.end();
         }
 
     }
 
     public TrinoDataPage next(String page, Map<String, String> extraCredentials) {
-        Span span = tracer.nextSpan().name("trinoNext");
-        try (Tracer.SpanInScope ws = tracer.withSpanInScope(span.start())) {
+        Span span = tracer.nextSpan().name("trinoNext").start();
+        try (Tracer.SpanInScope ws = tracer.withSpan(span)) {
             //TODO: better url construction
             String url = page.startsWith("/") ? this.trinoServer + page : this.trinoServer + "/" + page;
 
@@ -90,7 +87,7 @@ public class TrinoHttpClient implements TrinoClient {
                 throw new TrinoIOException("Unable to fetch more search or listing results (I/O error).", ie);
             }
         } finally {
-            span.finish();
+            span.end();
         }
     }
 
@@ -212,11 +209,15 @@ public class TrinoHttpClient implements TrinoClient {
 
     private Response execute(final Request.Builder request, Map<String, String> extraCredentials) throws IOException {
         request.header("X-Forwarded-Proto", "https");
-        request.header("X-Trino-Trace-Token",tracing.currentTraceContext().get().traceIdString());
-        if (tracing.currentTraceContext().get() != null) {
-            request.header("X-Trino-Trace-Token",tracing.currentTraceContext().get().traceIdString());
-            // We're adding the b3 contents to the Extra-Credential header, so we can extract it inside the SAC plugin & ga4gh-tables-connector
-            request.header("X-Trino-Extra-Credential", "b3=" + B3SingleFormat.writeB3SingleFormat(tracing.currentTraceContext().get()));
+        TraceContext traceContext = tracer.currentTraceContext().context();
+        if (traceContext != null) {
+            request.header("X-Trino-Trace-Token", traceContext.traceId());
+            // Pass W3C traceparent through to Trino as an extra credential so the SAC plugin &
+            // ga4gh-tables-connector can correlate downstream activity. Format follows the W3C Trace
+            // Context spec: version-traceId-spanId-flags.
+            String traceFlags = Boolean.TRUE.equals(traceContext.sampled()) ? "01" : "00";
+            String traceparent = "00-" + traceContext.traceId() + "-" + traceContext.spanId() + "-" + traceFlags;
+            request.header("X-Trino-Extra-Credential", "traceparent=" + traceparent);
         }
         extraCredentials.forEach((k, v) -> request.addHeader("X-Trino-Extra-Credential", k + "=" + v));
 

--- a/src/main/java/com/dnastack/ga4gh/dataconnect/adapter/trino/TrinoHttpClient.java
+++ b/src/main/java/com/dnastack/ga4gh/dataconnect/adapter/trino/TrinoHttpClient.java
@@ -212,11 +212,15 @@ public class TrinoHttpClient implements TrinoClient {
         TraceContext traceContext = tracer.currentTraceContext().context();
         if (traceContext != null) {
             request.header("X-Trino-Trace-Token", traceContext.traceId());
-            // Pass W3C traceparent through to Trino as an extra credential so the SAC plugin &
-            // ga4gh-tables-connector can correlate downstream activity. Format follows the W3C Trace
-            // Context spec: version-traceId-spanId-flags.
+            // Pass both the W3C traceparent and a legacy single-format B3 header through to Trino
+            // as extra credentials. The publisher SAC plugin and ga4gh-tables-connector currently
+            // read `b3`; once they migrate to the OpenTelemetry SPI (CU-86b9ybr65, CU-86b9ybr0e),
+            // the `b3` line can be removed in a follow-up to CU-86b9ybg6d.
             String traceFlags = Boolean.TRUE.equals(traceContext.sampled()) ? "01" : "00";
+            String b3SampledFlag = Boolean.TRUE.equals(traceContext.sampled()) ? "1" : "0";
             String traceparent = "00-" + traceContext.traceId() + "-" + traceContext.spanId() + "-" + traceFlags;
+            String b3 = traceContext.traceId() + "-" + traceContext.spanId() + "-" + b3SampledFlag;
+            request.header("X-Trino-Extra-Credential", "b3=" + b3);
             request.header("X-Trino-Extra-Credential", "traceparent=" + traceparent);
         }
         extraCredentials.forEach((k, v) -> request.addHeader("X-Trino-Extra-Credential", k + "=" + v));

--- a/src/main/java/com/dnastack/ga4gh/dataconnect/client/collectionservice/CollectionServiceClientConfiguration.java
+++ b/src/main/java/com/dnastack/ga4gh/dataconnect/client/collectionservice/CollectionServiceClientConfiguration.java
@@ -1,8 +1,12 @@
 package com.dnastack.ga4gh.dataconnect.client.collectionservice;
 
 import com.dnastack.ga4gh.dataconnect.DataModelSupplier;
-import com.dnastack.oauth.client.OAuthClientFactory;
+import com.dnastack.oauth.client.starter.config.OAuthClientFactoryConfiguration;
+import com.dnastack.oauth.feign.FeignClients;
+import com.dnastack.oauth.okhttp.OkHttpClients;
+import io.micrometer.observation.ObservationRegistry;
 import lombok.extern.slf4j.Slf4j;
+import okhttp3.OkHttpClient;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
@@ -13,9 +17,19 @@ import org.springframework.context.annotation.Configuration;
 public class CollectionServiceClientConfiguration {
     @Bean("collectionServiceClient")
     @ConditionalOnProperty(name = {"app.collection-service.enabled"}, havingValue = "true")
-    public CollectionServiceClient collectionServiceClient(OAuthClientFactory oAuthClientFactory, CollectionServiceConfiguration configuration) {
+    public CollectionServiceClient collectionServiceClient(
+        OAuthClientFactoryConfiguration oAuthClientFactoryConfiguration,
+        CollectionServiceConfiguration configuration,
+        ObservationRegistry observationRegistry
+    ) {
         log.info("Initializing the collection-service API client...");
-        return oAuthClientFactory.builderWithCommonSetup(configuration.getOauthClient())
+        OkHttpClient httpClient = OkHttpClients.buildOkHttpClient(
+            "collection-service", observationRegistry, CollectionServiceClient.class);
+        feign.okhttp.OkHttpClient feignClient = new feign.okhttp.OkHttpClient(httpClient);
+        return FeignClients.newBuilder(
+                oAuthClientFactoryConfiguration.getDefaultConfig().withOverrides(configuration.getOauthClient()),
+                feignClient,
+                feignClient)
             .target(CollectionServiceClient.class, configuration.getBaseUri());
     }
 

--- a/src/main/java/com/dnastack/ga4gh/dataconnect/client/indexingservice/IndexingServiceAutoConfiguration.java
+++ b/src/main/java/com/dnastack/ga4gh/dataconnect/client/indexingservice/IndexingServiceAutoConfiguration.java
@@ -1,8 +1,12 @@
 package com.dnastack.ga4gh.dataconnect.client.indexingservice;
 
 import com.dnastack.ga4gh.dataconnect.DataModelSupplier;
-import com.dnastack.oauth.client.OAuthClientFactory;
+import com.dnastack.oauth.client.starter.config.OAuthClientFactoryConfiguration;
+import com.dnastack.oauth.feign.FeignClients;
+import com.dnastack.oauth.okhttp.OkHttpClients;
+import io.micrometer.observation.ObservationRegistry;
 import lombok.extern.slf4j.Slf4j;
+import okhttp3.OkHttpClient;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
@@ -13,9 +17,19 @@ import org.springframework.context.annotation.Configuration;
 public class IndexingServiceAutoConfiguration {
     @Bean("indexingServiceClient")
     @ConditionalOnProperty(name = {"app.indexing-service.enabled"}, havingValue = "true")
-    public IndexingServiceClient indexingServiceClient(OAuthClientFactory factory, IndexingServiceConfiguration configuration) {
+    public IndexingServiceClient indexingServiceClient(
+        OAuthClientFactoryConfiguration oAuthClientFactoryConfiguration,
+        IndexingServiceConfiguration configuration,
+        ObservationRegistry observationRegistry
+    ) {
         log.info("Initializing the indexing service API client...");
-        return factory.builderWithCommonSetup(configuration.getOauthClient())
+        OkHttpClient httpClient = OkHttpClients.buildOkHttpClient(
+            "indexing-service", observationRegistry, IndexingServiceClient.class);
+        feign.okhttp.OkHttpClient feignClient = new feign.okhttp.OkHttpClient(httpClient);
+        return FeignClients.newBuilder(
+                oAuthClientFactoryConfiguration.getDefaultConfig().withOverrides(configuration.getOauthClient()),
+                feignClient,
+                feignClient)
             .target(IndexingServiceClient.class, configuration.getBaseUri());
     }
 

--- a/src/main/java/com/dnastack/ga4gh/dataconnect/client/tablesregistry/OAuthClientConfig.java
+++ b/src/main/java/com/dnastack/ga4gh/dataconnect/client/tablesregistry/OAuthClientConfig.java
@@ -3,7 +3,7 @@ package com.dnastack.ga4gh.dataconnect.client.tablesregistry;
 import com.dnastack.ga4gh.dataconnect.client.common.SimpleLogger;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import feign.Feign;
 import feign.Logger;
 import feign.codec.Encoder;
@@ -53,7 +53,7 @@ public class OAuthClientConfig {
     Encoder encoder;
 
     private ObjectMapper mapper = new ObjectMapper()
-        .setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE)
+        .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
         .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
     @Bean

--- a/src/main/java/com/dnastack/ga4gh/dataconnect/client/tablesregistry/TablesRegistryClientConfig.java
+++ b/src/main/java/com/dnastack/ga4gh/dataconnect/client/tablesregistry/TablesRegistryClientConfig.java
@@ -5,7 +5,7 @@ import com.dnastack.ga4gh.dataconnect.client.tablesregistry.model.AccessToken;
 import com.dnastack.ga4gh.dataconnect.client.tablesregistry.model.OAuthRequest;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import feign.Feign;
 import feign.Logger;
 import feign.RequestInterceptor;
@@ -42,7 +42,7 @@ public class TablesRegistryClientConfig {
     private OAuthClientConfig oAuthClientConfig;
 
     private ObjectMapper mapper = new ObjectMapper()
-            .setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE)
+            .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
             .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
     private OAuthRequest getOAuthRequest() {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -109,8 +109,6 @@ spring:
     driver-class-name: org.postgresql.Driver
     hikari:
       maximum-pool-size: 5
-  zipkin:
-    enabled: false
 
 management:
   metrics:

--- a/src/test/java/com/dnastack/ga4gh/dataconnect/adapter/trino/TrinoDataConnectAdapterTest.java
+++ b/src/test/java/com/dnastack/ga4gh/dataconnect/adapter/trino/TrinoDataConnectAdapterTest.java
@@ -1,7 +1,5 @@
 package com.dnastack.ga4gh.dataconnect.adapter.trino;
 
-import brave.Tracer;
-import brave.Tracing;
 import com.dnastack.ga4gh.dataconnect.ApplicationConfig;
 import com.dnastack.ga4gh.dataconnect.DataModelSupplier;
 import com.dnastack.ga4gh.dataconnect.adapter.trino.exception.TrinoNoSuchCatalogException;
@@ -15,6 +13,9 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import io.micrometer.tracing.CurrentTraceContext;
+import io.micrometer.tracing.TraceContext;
+import io.micrometer.tracing.Tracer;
 import lombok.extern.slf4j.Slf4j;
 import org.hamcrest.Matchers;
 import org.jdbi.v3.core.Jdbi;
@@ -47,8 +48,7 @@ public class TrinoDataConnectAdapterTest {
             .registerModule(new JavaTimeModule())
             .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
 
-    private Tracing tracing;
-    private Tracer.SpanInScope spanInScope;
+    private Tracer tracer;
 
     /**
      * The object under test
@@ -108,8 +108,14 @@ public class TrinoDataConnectAdapterTest {
 
     @Before
     public void setUp() throws Exception {
-        tracing = Tracing.newBuilder().build();
-        spanInScope = tracing.tracer().withSpanInScope(tracing.tracer().nextSpan());
+        // Minimal Tracer stub: only currentTraceContext().context().traceId() is exercised
+        // by the code under test (when persisting QueryJob.originalTraceId).
+        TraceContext traceContext = mock(TraceContext.class);
+        when(traceContext.traceId()).thenReturn("00000000000000000000000000000000");
+        CurrentTraceContext currentTraceContext = mock(CurrentTraceContext.class);
+        when(currentTraceContext.context()).thenReturn(traceContext);
+        tracer = mock(Tracer.class);
+        when(tracer.currentTraceContext()).thenReturn(currentTraceContext);
 
         // mock QueryJobDao and JDBI
         QueryJobDao queryJobDao = mock(QueryJobDao.class);
@@ -142,14 +148,12 @@ public class TrinoDataConnectAdapterTest {
         when(mockApplicationConfig.getHiddenCatalogs()).thenReturn(Collections.emptySet()); // Default: no hidden catalogs
 
         dataConnectAdapter = new TrinoDataConnectAdapter(
-                mockTrinoClient, jdbi, mockApplicationConfig, List.of(dataModelSupplier), tracing, Duration.ofMinutes(5),100
+                mockTrinoClient, jdbi, mockApplicationConfig, List.of(dataModelSupplier), tracer, Duration.ofMinutes(5),100
         );
     }
 
     @After
     public void tearDown() throws Exception {
-        spanInScope.close();
-        tracing.close();
     }
 
     private MockHttpServletRequest createRequestWithForwardedHeaders() {


### PR DESCRIPTION
## Summary

Migrates data-connect-trino off the pre-monorepo DNAstack 1.x libraries and onto `com.dnastack.starter:spring-boot-parent:4.0.0-rc2-9-gd79f5a8`. This is part of the parent ticket CU-86b9yb0pe to roll all services onto the consolidated java-libraries-monorepo.

Headline changes:

- **Parent POM**: swap `org.springframework.boot:spring-boot-starter-parent:3.5.13` for `com.dnastack.starter:spring-boot-parent:4.0.0-rc2-9-gd79f5a8`. Removes the local Jackson 2.18.x pin (no longer needed — every remaining caller uses `PropertyNamingStrategies.SNAKE_CASE`). Drops duplicate `<dependencyManagement>` entries (logback, jdbi, spring-cloud) and per-dep version pins for libs now managed by the parent (token-validator, audit-event-logger, oauth-client-factory-starter, jdbi, resilience4j, zonky).
- **Tracing**: `brave.Tracing` / `brave.Tracer` → `io.micrometer.tracing.Tracer` + `io.micrometer.observation.ObservationRegistry`. `micrometer-tracing-bridge-brave` → `bridge-otel`. `traceIdString()` (16 hex) → `traceId()` (32 hex / 128-bit) everywhere it surfaces (audit events, `X-Trino-Trace-Token`, `QueryJob.originalTraceId`, `trace_id` in error responses).
- **Token validator**: `JwtTokenParserFactory`, `PermissionCheckerFactory`, and `TokenActionsHttpClientFactory` migrated to their new `(ObservationRegistry, ConnectionPool)` signatures. Added `tokenValidatorConnectionPool` and `OidcHttpClient` beans; switched to `CachingIssuerPubKeyJwksResolver.create(issuerUri, oidcHttpClient)`.
- **OAuth Feign clients**: collection-service and indexing-service clients migrated from `OAuthClientFactory.builderWithCommonSetup(...)` to `FeignClients.newBuilder(cfg.withOverrides(oauthClient), feignClient, feignClient)`, with per-resource OkHttp clients built via `OkHttpClients.buildOkHttpClient(name, observationRegistry, type)` so metrics get meaningful resource dimensions.
- **Trino propagation**: `TrinoHttpClient.execute()` no longer emits a B3 single-format header inside `X-Trino-Extra-Credential` (Brave is gone). Replaced with W3C `traceparent` so the SAC plugin / tables connector can still correlate downstream activity; `X-Trino-Trace-Token` continues to carry the raw traceId.
- **Jackson 2.19 cleanup**: `PropertyNamingStrategy.SNAKE_CASE` → `PropertyNamingStrategies.SNAKE_CASE`; `PropertyNamingStrategy.KebabCaseStrategy` → `PropertyNamingStrategies.KebabCaseStrategy` (touches `DataConnectAuthRequest` and the two deprecated tables-registry client configs).
- **application.yml**: drop the now-dormant `spring.zipkin:` block (with Brave/Zipkin gone there's nothing to disable). Intentionally not adding `management.tracing.sampling.probability` — it's a no-op without an exporter.
- **Tests**: `TrinoDataConnectAdapterTest` swapped its live `brave.Tracing` fixture for a thin Mockito `Tracer` stub returning a fixed 128-bit traceId.

Commits are split logically so each is independently reviewable: parent bump, Jackson naming fixups, Brave + OAuthClientFactory migration, application.yml cleanup, test fixture swap.

## Test plan

- [x] `./mvnw clean test` — 49 tests pass locally (Java 21)
- [x] `./mvnw dependency:tree -Dincludes='com.dnastack:*'` — every DNAstack jar resolves to `4.0.0-rc2-9-gd79f5a8` (with `logback-extensions` correctly remaining on its standalone 1.0.1 line)
- [x] Verified audit events emit 128-bit (32-char) `trace_id` values
- [ ] CI green
- [ ] Integration deploy + smoke test against a real Trino + wallet