### PR TITLE
[CU-86ba9rz44] Bump spring-boot-parent to 4.0.1 to fix Tomcat/Netty CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.dnastack.starter</groupId>
     <artifactId>spring-boot-parent</artifactId>
-    <version>4.0.0</version>
+    <version>4.0.1</version>
     <relativePath/> <!-- lookup parent from repository -->
   </parent>
 


### PR DESCRIPTION
## Summary
- Bumps `spring-boot-parent` to `4.0.1`
- Fixes critical/high CVEs in Tomcat (10.1.54→10.1.55) and Netty (4.1.132→4.1.133): CVE-2026-41293, CVE-2026-43512, CVE-2026-43515, CVE-2026-42498, CVE-2026-43513, CVE-2026-41284, CVE-2026-42583, CVE-2026-42579, CVE-2026-42584, CVE-2026-42587

## Test plan
- [ ] CI passes

ClickUp: https://app.clickup.com/t/86ba9rz44

🤖 Generated with [Claude Code](https://claude.com/claude-code)